### PR TITLE
Improve `bootstrap.sh`

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -126,7 +126,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-TARBALL="${WORKDIR}/bundle.tar.gz"
+TARBALL="${WORKDIR}/$(basename "$TARBALL_URL")"
 SUMS="${WORKDIR}/SHA256SUMS"
 
 download_to_file "$TARBALL_URL" "$TARBALL"


### PR DESCRIPTION
This pull request updates the way the tarball file name is determined in the `cleanup()` function of `scripts/bootstrap.sh`. Instead of using a hardcoded name, it now dynamically uses the base name of the tarball URL.

* The `TARBALL` variable is now set to use `$(basename "$TARBALL_URL")`, ensuring the downloaded file retains its original name from the URL.