### PR TITLE
feat(build): native admin CLI + update-resistant installer (#19, #20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Build artifacts produced by scripts/build-bundle.sh
+/build/

--- a/README.md
+++ b/README.md
@@ -79,6 +79,42 @@ bash update.sh
 
 The script compares `/opt/moddex/VERSION` (if present) to the latest GitHub release tag and upgrades automatically. If Moddex is not installed yet, it offers to run the installer.
 
+## Command-line interface (`moddex`)
+
+The installer places an administrative CLI at `/usr/local/bin/moddex` so basic operations can be performed from the terminal without the web UI.
+
+```bash
+moddex help            # full command reference
+moddex status          # service state, endpoint and reachability
+moddex start|stop|restart
+moddex version         # version, build date and installation paths
+moddex logs [--follow] # tail the backend log
+```
+
+Instance-scoped commands talk to the backend REST API and therefore require authentication:
+
+```bash
+moddex list-instances
+moddex backup <instance-id> [--type standard|full]
+moddex restore <instance-id> <backup-name> [--yes]   # destructive, asks for confirmation
+```
+
+**Authentication.** Provide a JWT via `--token` / the `MODDEX_API_TOKEN` environment variable, or an admin password via `MODDEX_ADMIN_PASSWORD` (the CLI then logs in for you). Without either, the CLI prompts for the password interactively. The connection target is derived from `/etc/moddex/moddex.env` (`SERVER_ADDRESS`/`SERVER_PORT`); a wildcard bind is contacted on `127.0.0.1`.
+
+**Exit codes** are stable so the CLI can be used in scripts:
+
+| Code | Meaning |
+|------|---------|
+| `0` | success |
+| `1` | generic runtime error |
+| `2` | usage error (unknown command, missing/invalid arguments) |
+| `3` | service control failure or service not running |
+| `4` | authentication required or failed |
+| `5` | backend unreachable |
+| `6` | missing dependency (e.g. `curl`) |
+
+`list-instances` prints aligned columns when [`jq`](https://jqlang.github.io/jq/) is installed and falls back to raw JSON otherwise.
+
 ## Private Linux Operation
 
 This section is aimed at private administrators who want to run Moddex securely on a home server or in a local network (LAN). It describes secure defaults, explicit anti-patterns, and the system layout the installer creates.
@@ -106,12 +142,17 @@ Verzeichnisstruktur nach der Installation:
 | Pfad | Berechtigungen | Inhalt |
 |------|---------------|--------|
 | `/opt/moddex/` | `0755 moddex:moddex` | Anwendungsdateien (`app.jar`, `VERSION`) |
-| `/var/lib/moddex/` | `0755 moddex:moddex` | Laufzeitdaten (Datenbank, Konfiguration) |
+| `/var/lib/moddex/` | `0755 moddex:moddex` | Laufzeitdaten (Datenbank, Instanz- und Backup-Daten) |
 | `/var/lib/moddex/ui/` | `0755 moddex:moddex` | Statische Frontend-Assets |
-| `/var/lib/moddex/logs/` | `0755 moddex:moddex` | Backend-Logs (`backend.out.log`, `backend.err.log`) |
+| `/var/log/moddex/` | `0755 moddex:moddex` | Backend-Logs (`backend.out.log`, `backend.err.log`) |
+| `/etc/moddex/` | `0750 root:moddex` | Maschinen-lokale Konfiguration |
+| `/etc/moddex/moddex.env` | `0640 root:moddex` | Betriebsmodus, Bind-Adresse, Port (vom Installer geschrieben) |
 | `/etc/systemd/system/moddex-backend.service` | `0644 root:root` | Systemd-Unit |
+| `/usr/local/bin/moddex` | `0755 root:root` | Administrative CLI (siehe unten) |
 
-Der Dienst läuft niemals als `root`. Die Dateien unter `/opt/moddex` und `/var/lib/moddex` gehören `moddex:moddex` und sind für andere Benutzer nur lesbar.
+Der Dienst läuft niemals als `root`. Die Dateien unter `/opt/moddex` und `/var/lib/moddex` gehören `moddex:moddex` und sind für andere Benutzer nur lesbar. Die systemd-Unit ist zusätzlich gehärtet (`ProtectSystem=strict`, `NoNewPrivileges`, schreibbar nur unter `/var/lib/moddex` und `/var/log/moddex`).
+
+**Update-Resistenz:** Ein erneuter Installer-Lauf aktualisiert nur die Anwendungsartefakte (`app.jar`, Frontend, CLI, systemd-Unit). Die Datei `/etc/moddex/moddex.env` und sämtliche Instanz-/Backup-Daten unter `/var/lib/moddex` bleiben unangetastet. Um Modus oder Port nachträglich zu ändern, bearbeite `/etc/moddex/moddex.env` (oder starte den Installer mit `--mode`/`--port`) und führe anschließend `moddex restart` aus.
 
 ### Authentifizierung
 
@@ -129,7 +170,7 @@ Sichere Defaults für den Privatbetrieb:
 
 Passwörter und Tokens werden **nicht** vom Installer verwaltet; sie entstehen aus der laufenden Anwendung heraus. Hinterlege keine Zugangsdaten in der `moddex-backend.service`-Datei.
 
-> **Anti-Pattern:** Die CORS-Konfiguration des Backends erlaubt im Auslieferungszustand alle Ursprünge (`allowedOrigins = "*"`). Für öffentlichen Betrieb sollte der Reverse Proxy die erlaubten Ursprünge einschränken bzw. den Zugriff zusätzlich absichern.
+> **CORS:** Das Backend ist fail-closed konfiguriert. Im `local`-Modus sind nur Loopback-Ursprünge erlaubt; in `lan`/`public` ist Cross-Origin-Zugriff aus dem Browser deaktiviert, bis `MODDEX_CORS_ALLOWED_ORIGINS` (bzw. `moddex.security.cors.allowed-origins`) eine explizite Allow-List setzt. Siehe `docs/security-configuration.md` im Backend-Repo.
 
 ### Firewall (UFW / firewalld)
 
@@ -223,8 +264,8 @@ Für produktive oder sicherheitskritische Umgebungen diese Funktionen deaktivier
 - [ ] Installer mit `--mode lan` ausgeführt
 - [ ] UFW aktiv und nur notwendige Ports geöffnet
 - [ ] Router leitet Port **nicht** ins Internet weiter
-- [ ] Backend läuft als Benutzer `moddex` (prüfen: `systemctl status moddex-backend`)
-- [ ] Logs unter `/var/lib/moddex/logs/` erreichbar und lesbar
+- [ ] Backend läuft als Benutzer `moddex` (prüfen: `moddex status` oder `systemctl status moddex-backend`)
+- [ ] Logs unter `/var/log/moddex/` erreichbar und lesbar (`moddex logs`)
 - [ ] Regelmäßiges Backup von `/var/lib/moddex` eingerichtet
 - [ ] Experimentelle Funktionen nur bewusst aktivieren
 
@@ -259,3 +300,34 @@ and file operations cannot silently destroy instances:
   BASE_URL=http://127.0.0.1:8080 TOKEN=<jwt> INSTANCE_ID=<uuid> \
     scripts/smoke-test.sh            # add --with-restore for the destructive restore step
   ```
+
+### Debian/Ubuntu install smoke test
+
+After a fresh install on Debian 12 / Ubuntu 22.04+ (or a clean VM/container), verify the
+native deployment end to end:
+
+```bash
+# 1. Install (non-interactive). Pass the artifacts produced by build-bundle.sh.
+sudo ./scripts/install.sh --mode lan --port 8080
+
+# 2. Service is up and managed by systemd.
+moddex status                         # Active: active, Reachable: yes
+systemctl is-enabled moddex-backend   # enabled (starts on boot)
+
+# 3. Version and paths are reported.
+moddex version
+
+# 4. Auth is enforced before any token is issued.
+curl -i http://127.0.0.1:8080/api/v1/instance   # expect HTTP/1.1 401
+
+# 5. Complete the first-run setup in the web UI, then exercise the API:
+MODDEX_ADMIN_PASSWORD='<your-admin-password>' moddex list-instances
+
+# 6. Update resistance: re-running the installer must not touch local config/data.
+sudo ./scripts/install.sh             # reuses mode/port from /etc/moddex/moddex.env
+sudo cat /etc/moddex/moddex.env       # unchanged
+```
+
+Acceptance: after the installer the service is running under systemd and the web UI is
+reachable; a second installer run upgrades the artifacts without overwriting
+`/etc/moddex/moddex.env` or any instance data under `/var/lib/moddex`.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Verzeichnisstruktur nach der Installation:
 
 Der Dienst läuft niemals als `root`. Die Dateien unter `/opt/moddex` und `/var/lib/moddex` gehören `moddex:moddex` und sind für andere Benutzer nur lesbar. Die systemd-Unit ist zusätzlich gehärtet (`ProtectSystem=strict`, `NoNewPrivileges`, schreibbar nur unter `/var/lib/moddex` und `/var/log/moddex`).
 
-**Update-Resistenz:** Ein erneuter Installer-Lauf aktualisiert nur die Anwendungsartefakte (`app.jar`, Frontend, CLI, systemd-Unit). Die Datei `/etc/moddex/moddex.env` und sämtliche Instanz-/Backup-Daten unter `/var/lib/moddex` bleiben unangetastet. Um Modus oder Port nachträglich zu ändern, bearbeite `/etc/moddex/moddex.env` (oder starte den Installer mit `--mode`/`--port`) und führe anschließend `moddex restart` aus.
+**Update-Resistenz:** Ein erneuter Installer-Lauf **ohne** `--mode`/`--port` aktualisiert nur die Anwendungsartefakte (`app.jar`, Frontend, CLI, systemd-Unit); `/etc/moddex/moddex.env` und sämtliche Instanz-/Backup-Daten unter `/var/lib/moddex` bleiben unangetastet. Um Modus oder Port nachträglich zu ändern, starte den Installer **mit** explizitem `--mode`/`--port` (dann wird nur die betroffene Einstellung in `moddex.env` überschrieben) oder bearbeite die Datei direkt; anschließend `moddex restart` ausführen.
 
 ### Authentifizierung
 

--- a/packaging/systemd/moddex-backend.service
+++ b/packaging/systemd/moddex-backend.service
@@ -1,21 +1,50 @@
 [Unit]
 Description=Moddex Backend API
-After=network.target
+Documentation=https://github.com/aklozyp/Moddex
+After=network-online.target
+Wants=network-online.target
 
 [Service]
+Type=simple
 User=moddex
 Group=moddex
 WorkingDirectory=/opt/moddex
+
+# Runtime configuration. The installer writes machine-local settings (bind
+# address, port, mode) into /etc/moddex/moddex.env. The leading "-" makes the
+# file optional so the unit still starts if it is absent. Updates never
+# overwrite this file, so local settings survive upgrades.
+EnvironmentFile=-/etc/moddex/moddex.env
 Environment=MODDEX_ROOT=/var/lib/moddex
-Environment=MODDEX_LOG_DIR=/var/lib/moddex/logs
+Environment=MODDEX_CONFIG_DIR=/etc/moddex
+Environment=MODDEX_LOG_DIR=/var/log/moddex
 Environment=SERVER_ADDRESS=127.0.0.1
 Environment=SERVER_PORT=8080
+
 ExecStart=/usr/bin/env java -jar /opt/moddex/app.jar
 Restart=on-failure
 RestartSec=5
+# 143 = SIGTERM, 130 = SIGINT: clean shutdowns must not count as failures.
 SuccessExitStatus=143 130
-StandardOutput=append:/var/lib/moddex/logs/backend.out.log
-StandardError=append:/var/lib/moddex/logs/backend.err.log
+
+StandardOutput=append:/var/log/moddex/backend.out.log
+StandardError=append:/var/log/moddex/backend.err.log
+
+# --- Hardening ---------------------------------------------------------------
+# The service only needs to write to its data and log directories; everything
+# else is read-only or inaccessible. ReadWritePaths must list every writable
+# location the backend touches at runtime.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+ReadWritePaths=/var/lib/moddex /var/log/moddex
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -263,6 +263,22 @@ EOF
   chmod 0640 "$ENV_FILE"
 }
 
+# Update (or append) a single KEY=value line in $ENV_FILE in place, leaving every
+# other line untouched. Used when an operator changes only --mode/--port so any
+# custom keys they added (e.g. MODDEX_CORS_ALLOWED_ORIGINS) are preserved.
+upsert_env_key() {
+  local key="$1" value="$2" tmp
+  tmp="$(mktemp "${ENV_FILE}.XXXXXX")"
+  awk -v k="$key" -v v="$value" '
+    index($0, k"=") == 1 { print k"="v; done=1; next }
+    { print }
+    END { if (!done) print k"="v }
+  ' "$ENV_FILE" > "$tmp"
+  chown root:moddex "$tmp" 2>/dev/null || true
+  chmod 0640 "$tmp"
+  mv -f "$tmp" "$ENV_FILE"
+}
+
 if [[ "$CONFIG_EXISTS" -eq 1 ]]; then
   # Baseline values from the existing file.
   # shellcheck disable=SC1090
@@ -277,7 +293,11 @@ if [[ "$CONFIG_EXISTS" -eq 1 ]]; then
     # keep the operator's existing bind address rather than recomputing it.
     [[ "$MODE_EXPLICIT" -eq 1 || -z "$EXISTING_ADDR" ]] || SERVER_ADDRESS="$EXISTING_ADDR"
     log "Updating configuration at $ENV_FILE (explicit --mode/--port given)"
-    write_env_file
+    # Touch only the managed connection keys; preserve any operator-added lines.
+    upsert_env_key MODDEX_MODE "$MODE"
+    upsert_env_key MODDEX_SECURITY_MODE "$MODE"
+    upsert_env_key SERVER_ADDRESS "$SERVER_ADDRESS"
+    upsert_env_key SERVER_PORT "$SERVER_PORT"
   else
     log "Preserving existing configuration at $ENV_FILE (pass --mode/--port to change it)"
     [[ -n "$EXISTING_PORT" ]] && SERVER_PORT="$EXISTING_PORT"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,6 +25,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SYSTEMD_DIR="$PROJECT_ROOT/packaging/systemd"
 
+# Filesystem layout (FHS-aligned). The backend reads these via MODDEX_* env vars
+# (see application.yml), so the installer, systemd unit and CLI all agree.
+APP_DIR=/opt/moddex
+DATA_DIR=/var/lib/moddex
+CONFIG_DIR=/etc/moddex
+LOG_DIR=/var/log/moddex
+ENV_FILE="$CONFIG_DIR/moddex.env"
+CLI_PATH=/usr/local/bin/moddex
+MIN_JAVA_VERSION=17
+
 MODE="${MODE:-${MODDEX_MODE:-}}"
 BACKEND_JAR="${BACKEND_JAR:-${MODDEX_BACKEND_JAR:-}}"
 FRONTEND_DIR="${FRONTEND_DIR:-${MODDEX_FRONTEND_DIR:-}}"
@@ -47,6 +57,10 @@ Options:
 
 Environment overrides:
   MODDEX_MODE, MODDEX_BACKEND_JAR, MODDEX_FRONTEND_DIR, MODDEX_PORT
+
+The installer is idempotent: re-running it upgrades the application artifacts
+without touching local configuration in /etc/moddex/moddex.env or instance data
+in /var/lib/moddex.
 USAGE
 }
 
@@ -61,16 +75,36 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# An existing config file marks an upgrade. We keep the operator's mode/port from
+# the previous install unless they are overridden on the command line, so updates
+# stay non-destructive.
+CONFIG_EXISTS=0
+EXISTING_MODE=""
+if [[ -f "$ENV_FILE" ]]; then
+  CONFIG_EXISTS=1
+  # shellcheck disable=SC1090
+  EXISTING_MODE="$(. "$ENV_FILE" 2>/dev/null; printf '%s' "${MODDEX_MODE:-}")"
+fi
+
+if [[ -z "$MODE" && -n "$EXISTING_MODE" ]]; then
+  MODE="$EXISTING_MODE"
+  log "Reusing existing deployment mode from $ENV_FILE: $MODE"
+fi
+
 if [[ -z "$MODE" ]]; then
-  log "In which mode do you want to operate Moddex?"
-  select mode_option in "lan (recommended)" "local (dev only)" "public"; do
-    case "$mode_option" in
-      "lan (recommended)") MODE="lan"; break ;;
-      "local (dev only)") MODE="local"; break ;;
-      "public") MODE="public"; break ;;
-      *) echo "Invalid option. Please try again." ;;
-    esac
-  done
+  if [[ -t 0 ]]; then
+    log "In which mode do you want to operate Moddex?"
+    select mode_option in "lan (recommended)" "local (dev only)" "public"; do
+      case "$mode_option" in
+        "lan (recommended)") MODE="lan"; break ;;
+        "local (dev only)") MODE="local"; break ;;
+        "public") MODE="public"; break ;;
+        *) echo "Invalid option. Please try again." ;;
+      esac
+    done
+  else
+    die "No --mode given and not running interactively. Pass --mode local|lan|public."
+  fi
 fi
 
 MODE="${MODE,,}"
@@ -101,7 +135,6 @@ fi
 need_cmd install
 need_cmd rsync
 need_cmd systemctl
-need_cmd java
 
 log "Ensuring required packages are installed"
 if command -v apt-get >/dev/null 2>&1; then
@@ -109,41 +142,109 @@ if command -v apt-get >/dev/null 2>&1; then
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openjdk-17-jre-headless rsync >/dev/null
 fi
 
+# Verify a usable Java runtime is present (after the optional apt install above).
+need_cmd java
+java_major() {
+  # Parses "17.0.10", "1.8.0_392" etc. from `java -version` into a major number.
+  local raw
+  raw="$(java -version 2>&1 | head -n1 | sed -E 's/.*version "([0-9._]+)".*/\1/')"
+  if [[ "$raw" == 1.* ]]; then
+    printf '%s' "${raw#1.}" | cut -d. -f1
+  else
+    printf '%s' "$raw" | cut -d. -f1
+  fi
+}
+JAVA_MAJOR="$(java_major)"
+if [[ -z "$JAVA_MAJOR" || ! "$JAVA_MAJOR" =~ ^[0-9]+$ ]]; then
+  die "Could not determine the installed Java version. Install OpenJDK $MIN_JAVA_VERSION or newer."
+fi
+if (( JAVA_MAJOR < MIN_JAVA_VERSION )); then
+  die "Java $MIN_JAVA_VERSION or newer is required (found major version $JAVA_MAJOR)."
+fi
+log "Using Java major version $JAVA_MAJOR"
+
 log "Creating moddex user and directories"
 if ! id -u moddex >/dev/null 2>&1; then
-  useradd -r -M -s /usr/sbin/nologin -d /opt/moddex moddex
+  useradd -r -M -s /usr/sbin/nologin -d "$APP_DIR" moddex
 fi
 
-install -d -m 0755 -o moddex -g moddex /opt/moddex
-install -d -m 0755 -o moddex -g moddex /var/lib/moddex
-install -d -m 0755 -o moddex -g moddex /var/lib/moddex/ui
-install -d -m 0755 -o moddex -g moddex /var/lib/moddex/logs
+install -d -m 0755 -o moddex -g moddex "$APP_DIR"
+install -d -m 0755 -o moddex -g moddex "$DATA_DIR"
+install -d -m 0755 -o moddex -g moddex "$DATA_DIR/ui"
+install -d -m 0755 -o moddex -g moddex "$LOG_DIR"
+# Config is root-owned but group-readable by the service so secrets in moddex.env
+# are not world-readable.
+install -d -m 0750 -o root -g moddex "$CONFIG_DIR"
+
+# One-time migration: older installs logged to /var/lib/moddex/logs.
+if [[ -d "$DATA_DIR/logs" && ! -e "$LOG_DIR/backend.out.log" ]]; then
+  log "Migrating existing logs from $DATA_DIR/logs to $LOG_DIR"
+  cp -a "$DATA_DIR/logs/." "$LOG_DIR/" 2>/dev/null || true
+  chown -R moddex:moddex "$LOG_DIR"
+fi
 
 log "Deploying backend artifact"
-install -m 0644 "$BACKEND_JAR" /opt/moddex/app.jar
-chown moddex:moddex /opt/moddex/app.jar
+install -m 0644 "$BACKEND_JAR" "$APP_DIR/app.jar"
+chown moddex:moddex "$APP_DIR/app.jar"
+
+# Record the installed version so update.sh can compare against the latest tag.
+VERSION_STRING="${VERSION:-}"
+if [[ -z "$VERSION_STRING" && -f "$PROJECT_ROOT/VERSION" ]]; then
+  VERSION_STRING="$(sed -n '1p' "$PROJECT_ROOT/VERSION" | tr -d '\r\n')"
+fi
+[[ -n "$VERSION_STRING" ]] || VERSION_STRING="dev"
+printf '%s\n' "$VERSION_STRING" > "$APP_DIR/VERSION"
+chown moddex:moddex "$APP_DIR/VERSION"
+log "Installed version: $VERSION_STRING"
 
 if [[ -n "$FRONTEND_DIR" ]]; then
   log "Deploying frontend assets from $FRONTEND_DIR"
-  rsync -a --delete --chown=moddex:moddex "$FRONTEND_DIR/" /var/lib/moddex/ui/
+  rsync -a --delete --chown=moddex:moddex "$FRONTEND_DIR/" "$DATA_DIR/ui/"
 else
   log "Skipping frontend asset deployment (no build directory provided)"
 fi
 
 case "$MODE" in
-  local)
-    SERVER_ADDRESS="127.0.0.1"
-    ;;
-  lan|public)
-    SERVER_ADDRESS="0.0.0.0"
-    ;;
+  local) SERVER_ADDRESS="127.0.0.1" ;;
+  lan|public) SERVER_ADDRESS="0.0.0.0" ;;
 esac
+
+# Machine-local runtime configuration. Written once; left untouched on upgrades
+# so operator settings survive. To change mode/port later, edit this file (or
+# re-run with --mode/--port) and restart the service.
+if [[ "$CONFIG_EXISTS" -eq 1 ]]; then
+  log "Preserving existing configuration at $ENV_FILE (edit it to change mode/port)"
+  # shellcheck disable=SC1090
+  SERVER_PORT="$(. "$ENV_FILE" 2>/dev/null; printf '%s' "${SERVER_PORT:-$SERVER_PORT}")"
+else
+  log "Writing configuration to $ENV_FILE"
+  umask 027
+  cat > "$ENV_FILE" <<EOF
+# Moddex machine-local configuration. Managed by the operator.
+# The installer does NOT overwrite this file on upgrades.
+MODDEX_MODE=$MODE
+MODDEX_ROOT=$DATA_DIR
+MODDEX_CONFIG_DIR=$CONFIG_DIR
+MODDEX_LOG_DIR=$LOG_DIR
+SERVER_ADDRESS=$SERVER_ADDRESS
+SERVER_PORT=$SERVER_PORT
+EOF
+  umask 022
+  chown root:moddex "$ENV_FILE"
+  chmod 0640 "$ENV_FILE"
+fi
 
 SERVICE_FILE=/etc/systemd/system/moddex-backend.service
 log "Writing systemd service to $SERVICE_FILE"
 install -m 0644 "$SYSTEMD_DIR/moddex-backend.service" "$SERVICE_FILE"
-sed -i "s/^Environment=SERVER_ADDRESS=.*/Environment=SERVER_ADDRESS=$SERVER_ADDRESS/" "$SERVICE_FILE"
-sed -i "s/^Environment=SERVER_PORT=.*/Environment=SERVER_PORT=$SERVER_PORT/" "$SERVICE_FILE"
+
+# Install the administrative CLI into PATH (idempotent overwrite).
+if [[ -f "$SCRIPT_DIR/moddex" ]]; then
+  log "Installing CLI to $CLI_PATH"
+  install -m 0755 "$SCRIPT_DIR/moddex" "$CLI_PATH"
+else
+  log "CLI script not found next to installer; skipping CLI installation"
+fi
 
 log "Reloading systemd and starting backend"
 systemctl daemon-reload
@@ -162,19 +263,18 @@ fi
 
 log "Installation complete"
 case "$MODE" in
-  local)
-    printf 'Backend API reachable at: http://127.0.0.1:%s\n' "$SERVER_PORT"
-    ;;
-  lan)
-    printf 'Backend API reachable at: http://<server-ip>:%s\n' "$SERVER_PORT"
-    ;;
-  public)
-    printf 'Backend API reachable at: http://<public-host>:%s (no TLS configured)\n' "$SERVER_PORT"
-    ;;
+  local) printf 'Backend API reachable at: http://127.0.0.1:%s\n' "$SERVER_PORT" ;;
+  lan)   printf 'Backend API reachable at: http://<server-ip>:%s\n' "$SERVER_PORT" ;;
+  public) printf 'Backend API reachable at: http://<public-host>:%s (no TLS configured)\n' "$SERVER_PORT" ;;
 esac
 printf 'Systemd unit: moddex-backend.service\n'
+printf 'Configuration: %s\n' "$ENV_FILE"
+printf 'Logs: %s\n' "$LOG_DIR"
+if command -v moddex >/dev/null 2>&1 || [[ -x "$CLI_PATH" ]]; then
+  printf 'CLI installed: run "moddex status" or "moddex help".\n'
+fi
 if [[ -n "$FRONTEND_DIR" ]]; then
-  printf 'Static frontend copied to /var/lib/moddex/ui (serve separately).\n'
+  printf 'Static frontend copied to %s/ui (serve separately).\n' "$DATA_DIR"
 fi
 printf 'Complete the first-run setup in the web UI to set an admin password. Then verify a protected endpoint returns 401 without a token, e.g.:\n'
 printf '  curl -i http://127.0.0.1:%s/api/v1/instance\n' "$SERVER_PORT"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -230,6 +230,9 @@ write_env_file() {
 # The installer rewrites this file only when --mode/--port (or MODDEX_MODE/
 # MODDEX_PORT) are given explicitly; plain upgrades leave it untouched.
 MODDEX_MODE=$MODE
+# Drives the backend's CORS/security policy (moddex.security.mode); must match
+# MODDEX_MODE so a lan/public install does not run with the local default.
+MODDEX_SECURITY_MODE=$MODE
 MODDEX_ROOT=$DATA_DIR
 MODDEX_CONFIG_DIR=$CONFIG_DIR
 MODDEX_LOG_DIR=$LOG_DIR

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -101,6 +101,25 @@ if [[ -z "$MODE" && -n "$EXISTING_MODE" ]]; then
   log "Reusing existing deployment mode from $ENV_FILE: $MODE"
 fi
 
+# Legacy migration: installs from the previous installer have no moddex.env but a
+# systemd unit carrying SERVER_ADDRESS/SERVER_PORT. Recover them so unattended
+# upgrades (update.sh/download.sh, which call install.sh without --mode) keep
+# working instead of failing the non-interactive guard below.
+LEGACY_SERVICE_FILE=/etc/systemd/system/moddex-backend.service
+if [[ -z "$MODE" && "$CONFIG_EXISTS" -eq 0 && -f "$LEGACY_SERVICE_FILE" ]]; then
+  legacy_addr="$(sed -n 's/^Environment=SERVER_ADDRESS=//p' "$LEGACY_SERVICE_FILE" | tail -n1 | tr -d '\r')"
+  legacy_port="$(sed -n 's/^Environment=SERVER_PORT=//p' "$LEGACY_SERVICE_FILE" | tail -n1 | tr -d '\r')"
+  if [[ -n "$legacy_addr" ]]; then
+    case "$legacy_addr" in
+      127.0.0.1|localhost|::1) MODE="local" ;;
+      *) MODE="lan" ;;   # 0.0.0.0 etc.: lan is the safe non-public default
+    esac
+    # Keep the previous port unless the operator overrode it explicitly.
+    [[ "$PORT_EXPLICIT" -eq 1 || -z "$legacy_port" ]] || SERVER_PORT="$legacy_port"
+    log "Migrating configuration from existing systemd unit (mode=$MODE, port=$SERVER_PORT)"
+  fi
+fi
+
 if [[ -z "$MODE" ]]; then
   if [[ -t 0 ]]; then
     log "In which mode do you want to operate Moddex?"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -38,7 +38,17 @@ MIN_JAVA_VERSION=17
 MODE="${MODE:-${MODDEX_MODE:-}}"
 BACKEND_JAR="${BACKEND_JAR:-${MODDEX_BACKEND_JAR:-}}"
 FRONTEND_DIR="${FRONTEND_DIR:-${MODDEX_FRONTEND_DIR:-}}"
-SERVER_PORT="${PORT:-${MODDEX_PORT:-8080}}"
+
+# Track whether mode/port were given explicitly (env var or CLI flag) vs left at
+# their default. On a re-install we only rewrite an existing moddex.env when the
+# operator actually supplied an override, so unattended upgrades stay
+# non-destructive but an explicit `--mode/--port` re-run still takes effect.
+MODE_EXPLICIT=0
+[[ -n "$MODE" ]] && MODE_EXPLICIT=1
+PORT_INPUT="${PORT:-${MODDEX_PORT:-}}"
+PORT_EXPLICIT=0
+[[ -n "$PORT_INPUT" ]] && PORT_EXPLICIT=1
+SERVER_PORT="${PORT_INPUT:-8080}"
 
 log() { printf '[moddex-install] %s\n' "$*"; }
 die() { printf '[ERROR] %s\n' "$*" >&2; exit 1; }
@@ -66,10 +76,10 @@ USAGE
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --mode) [[ $# -ge 2 ]] || die "Missing value for --mode"; MODE="$2"; shift 2 ;;
+    --mode) [[ $# -ge 2 ]] || die "Missing value for --mode"; MODE="$2"; MODE_EXPLICIT=1; shift 2 ;;
     --backend-jar) [[ $# -ge 2 ]] || die "Missing value for --backend-jar"; BACKEND_JAR="$2"; shift 2 ;;
     --frontend-dir) [[ $# -ge 2 ]] || die "Missing value for --frontend-dir"; FRONTEND_DIR="$2"; shift 2 ;;
-    --port) [[ $# -ge 2 ]] || die "Missing value for --port"; SERVER_PORT="$2"; shift 2 ;;
+    --port) [[ $# -ge 2 ]] || die "Missing value for --port"; SERVER_PORT="$2"; PORT_EXPLICIT=1; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) die "Unknown argument: $1" ;;
   esac
@@ -209,19 +219,16 @@ case "$MODE" in
   lan|public) SERVER_ADDRESS="0.0.0.0" ;;
 esac
 
-# Machine-local runtime configuration. Written once; left untouched on upgrades
-# so operator settings survive. To change mode/port later, edit this file (or
-# re-run with --mode/--port) and restart the service.
-if [[ "$CONFIG_EXISTS" -eq 1 ]]; then
-  log "Preserving existing configuration at $ENV_FILE (edit it to change mode/port)"
-  # shellcheck disable=SC1090
-  SERVER_PORT="$(. "$ENV_FILE" 2>/dev/null; printf '%s' "${SERVER_PORT:-$SERVER_PORT}")"
-else
-  log "Writing configuration to $ENV_FILE"
+# Machine-local runtime configuration. On a fresh install it is written once. On
+# a re-install it is only rewritten when the operator passes an explicit
+# --mode/--port (or MODDEX_MODE/MODDEX_PORT); otherwise it is preserved so plain
+# upgrades never disturb operator settings.
+write_env_file() {
   umask 027
   cat > "$ENV_FILE" <<EOF
 # Moddex machine-local configuration. Managed by the operator.
-# The installer does NOT overwrite this file on upgrades.
+# The installer rewrites this file only when --mode/--port (or MODDEX_MODE/
+# MODDEX_PORT) are given explicitly; plain upgrades leave it untouched.
 MODDEX_MODE=$MODE
 MODDEX_ROOT=$DATA_DIR
 MODDEX_CONFIG_DIR=$CONFIG_DIR
@@ -232,6 +239,31 @@ EOF
   umask 022
   chown root:moddex "$ENV_FILE"
   chmod 0640 "$ENV_FILE"
+}
+
+if [[ "$CONFIG_EXISTS" -eq 1 ]]; then
+  # Baseline values from the existing file.
+  # shellcheck disable=SC1090
+  EXISTING_PORT="$(. "$ENV_FILE" 2>/dev/null; printf '%s' "${SERVER_PORT:-}")"
+  # shellcheck disable=SC1090
+  EXISTING_ADDR="$(. "$ENV_FILE" 2>/dev/null; printf '%s' "${SERVER_ADDRESS:-}")"
+
+  if [[ "$MODE_EXPLICIT" -eq 1 || "$PORT_EXPLICIT" -eq 1 ]]; then
+    # Honor explicit overrides; keep non-overridden values from the existing file.
+    [[ "$PORT_EXPLICIT" -eq 1 || -z "$EXISTING_PORT" ]] || SERVER_PORT="$EXISTING_PORT"
+    # SERVER_ADDRESS was derived from MODE above. If the mode was not overridden,
+    # keep the operator's existing bind address rather than recomputing it.
+    [[ "$MODE_EXPLICIT" -eq 1 || -z "$EXISTING_ADDR" ]] || SERVER_ADDRESS="$EXISTING_ADDR"
+    log "Updating configuration at $ENV_FILE (explicit --mode/--port given)"
+    write_env_file
+  else
+    log "Preserving existing configuration at $ENV_FILE (pass --mode/--port to change it)"
+    [[ -n "$EXISTING_PORT" ]] && SERVER_PORT="$EXISTING_PORT"
+    [[ -n "$EXISTING_ADDR" ]] && SERVER_ADDRESS="$EXISTING_ADDR"
+  fi
+else
+  log "Writing configuration to $ENV_FILE"
+  write_env_file
 fi
 
 SERVICE_FILE=/etc/systemd/system/moddex-backend.service

--- a/scripts/moddex
+++ b/scripts/moddex
@@ -1,0 +1,425 @@
+#!/usr/bin/env bash
+#
+# moddex - administrative CLI for a native Moddex installation.
+#
+# Wraps the systemd service and the backend REST API so admins can run basic
+# operations from the terminal without the web UI. Installed to
+# /usr/local/bin/moddex by scripts/install.sh.
+#
+# Stable exit codes (do not renumber - scripts/automation may rely on them):
+#   0  success
+#   1  generic runtime error
+#   2  usage error (unknown command, missing or invalid arguments)
+#   3  service control failure (systemctl) or service not running
+#   4  authentication required or failed
+#   5  backend unreachable
+#   6  missing dependency (e.g. curl)
+#
+set -Eeuo pipefail
+
+readonly EX_OK=0
+readonly EX_ERR=1
+readonly EX_USAGE=2
+readonly EX_SERVICE=3
+readonly EX_AUTH=4
+readonly EX_UNREACHABLE=5
+readonly EX_DEP=6
+
+readonly SERVICE="moddex-backend.service"
+
+# FHS layout - kept in lock-step with scripts/install.sh and the systemd unit.
+APP_DIR="${MODDEX_APP_DIR:-/opt/moddex}"
+DATA_DIR="${MODDEX_ROOT:-/var/lib/moddex}"
+CONFIG_DIR="${MODDEX_CONFIG_DIR:-/etc/moddex}"
+LOG_DIR="${MODDEX_LOG_DIR:-/var/log/moddex}"
+ENV_FILE="${CONFIG_DIR}/moddex.env"
+
+log()  { printf '%s\n' "$*"; }
+err()  { printf 'moddex: %s\n' "$*" >&2; }
+die()  { local code="$1"; shift; err "$*"; exit "$code"; }
+need_cmd() { command -v "$1" >/dev/null 2>&1 || die "$EX_DEP" "missing required command: $1"; }
+
+# ---------------------------------------------------------------------------
+# Configuration / connection details
+# ---------------------------------------------------------------------------
+
+# Load SERVER_ADDRESS / SERVER_PORT from the machine-local env file if present.
+# Values already set in the environment win, so callers can override per-run.
+load_env() {
+    if [[ -r "$ENV_FILE" ]]; then
+        local addr port
+        # Read without polluting the current shell beyond what we extract.
+        addr="$(. "$ENV_FILE" 2>/dev/null; printf '%s' "${SERVER_ADDRESS:-}")"
+        port="$(. "$ENV_FILE" 2>/dev/null; printf '%s' "${SERVER_PORT:-}")"
+        [[ -z "${SERVER_ADDRESS:-}" && -n "$addr" ]] && SERVER_ADDRESS="$addr"
+        [[ -z "${SERVER_PORT:-}" && -n "$port" ]] && SERVER_PORT="$port"
+    fi
+    SERVER_PORT="${SERVER_PORT:-8080}"
+    SERVER_ADDRESS="${SERVER_ADDRESS:-127.0.0.1}"
+}
+
+# Base URL for API calls. A wildcard bind (0.0.0.0 / ::) is not connectable, so
+# the CLI always talks to loopback from the same host.
+base_url() {
+    load_env
+    local host="$SERVER_ADDRESS"
+    case "$host" in
+        0.0.0.0|""|"::"|"[::]") host="127.0.0.1" ;;
+    esac
+    printf 'http://%s:%s' "$host" "$SERVER_PORT"
+}
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+# Emits the HTTP status code for a request (000 means no response). curl's exit
+# status is swallowed so a connection failure does not abort the script under
+# `set -e`; callers branch on the emitted code instead.
+http_status() {
+    local method="$1" path="$2"; shift 2
+    curl -s -o /dev/null -w '%{http_code}' -X "$method" "$@" "$(base_url)${path}" || true
+}
+
+# Emits the response body (stdout) and the status code (last line) separated by
+# a newline so callers can inspect both. As above, curl failures are swallowed.
+http_body_status() {
+    local method="$1" path="$2"; shift 2
+    curl -s -w '\n%{http_code}' -X "$method" "$@" "$(base_url)${path}" || true
+}
+
+TOKEN="${MODDEX_API_TOKEN:-}"
+
+# Resolves a bearer token for authenticated API calls. Order of precedence:
+#   1. --token / MODDEX_API_TOKEN (already in $TOKEN)
+#   2. MODDEX_ADMIN_PASSWORD -> POST /api/v1/auth/login
+#   3. interactive password prompt -> login
+ensure_token() {
+    need_cmd curl
+    [[ -n "$TOKEN" ]] && return 0
+
+    local password="${MODDEX_ADMIN_PASSWORD:-}"
+    if [[ -z "$password" ]]; then
+        if [[ -t 0 ]]; then
+            printf 'Admin password: ' >&2
+            read -r -s password
+            printf '\n' >&2
+        else
+            die "$EX_AUTH" "no token available. Set MODDEX_API_TOKEN or MODDEX_ADMIN_PASSWORD, or run interactively."
+        fi
+    fi
+    [[ -n "$password" ]] || die "$EX_AUTH" "empty password; cannot authenticate."
+
+    local out status body
+    # Build the JSON body without exposing the password on the command line.
+    out="$(printf '{"password":%s}' "$(json_string "$password")" \
+        | curl -s -w '\n%{http_code}' -X POST \
+            -H 'Content-Type: application/json' \
+            --data @- "$(base_url)/api/v1/auth/login")" || true
+    status="${out##*$'\n'}"
+    body="${out%$'\n'*}"
+
+    case "$status" in
+        200) ;;
+        000) die "$EX_UNREACHABLE" "backend unreachable at $(base_url)." ;;
+        401) die "$EX_AUTH" "invalid admin password." ;;
+        403) die "$EX_AUTH" "setup not completed yet; finish the first-run setup in the web UI." ;;
+        429) die "$EX_AUTH" "too many failed login attempts; try again later." ;;
+        *)   die "$EX_AUTH" "login failed (HTTP $status)." ;;
+    esac
+
+    TOKEN="$(printf '%s' "$body" | extract_json_string token)"
+    [[ -n "$TOKEN" ]] || die "$EX_AUTH" "login succeeded but no token was returned."
+}
+
+auth_header() { printf 'Authorization: Bearer %s' "$TOKEN"; }
+
+# ---------------------------------------------------------------------------
+# Minimal JSON helpers (jq when available, portable fallback otherwise)
+# ---------------------------------------------------------------------------
+
+have_jq() { command -v jq >/dev/null 2>&1; }
+
+# Quotes an arbitrary string as a JSON string literal.
+json_string() {
+    if have_jq; then
+        printf '%s' "$1" | jq -Rs .
+    else
+        local s="$1"
+        s="${s//\\/\\\\}"
+        s="${s//\"/\\\"}"
+        printf '"%s"' "$s"
+    fi
+}
+
+# Extracts a top-level string field from a JSON object on stdin.
+extract_json_string() {
+    local key="$1"
+    if have_jq; then
+        jq -r --arg k "$key" '.[$k] // empty'
+    else
+        # Best-effort regex fallback for flat objects: "key":"value".
+        grep -o "\"$key\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" \
+            | head -n1 | sed 's/.*:[[:space:]]*"//;s/"$//'
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Service control (needs root; re-exec via sudo when necessary)
+# ---------------------------------------------------------------------------
+
+reexec_root() {
+    if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+        if command -v sudo >/dev/null 2>&1; then
+            exec sudo -E "$0" "$@"
+        fi
+        die "$EX_SERVICE" "this command needs root privileges (install sudo or run as root)."
+    fi
+}
+
+service_action() {
+    local action="$1"
+    need_cmd systemctl
+    reexec_root "$action"
+    if systemctl "$action" "$SERVICE"; then
+        log "$SERVICE: $action ok"
+    else
+        die "$EX_SERVICE" "systemctl $action $SERVICE failed."
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+cmd_status() {
+    need_cmd systemctl
+    local active enabled
+    active="$(systemctl is-active "$SERVICE" 2>/dev/null || true)"
+    enabled="$(systemctl is-enabled "$SERVICE" 2>/dev/null || true)"
+    log "Service:   $SERVICE"
+    log "Active:    ${active:-unknown}"
+    log "Enabled:   ${enabled:-unknown}"
+    log "Endpoint:  $(base_url)"
+
+    local reachable="no" code=""
+    if command -v curl >/dev/null 2>&1; then
+        # /api/v1/setup/status is unauthenticated, so any HTTP response proves
+        # the backend is up without needing a token.
+        code="$(http_status GET /api/v1/setup/status || true)"
+        [[ -n "$code" && "$code" != "000" ]] && reachable="yes"
+    else
+        code="curl-missing"
+    fi
+    log "Reachable: $reachable${code:+ (HTTP $code)}"
+
+    [[ "$active" == "active" ]] || return "$EX_SERVICE"
+    [[ "$reachable" == "yes" ]] || return "$EX_UNREACHABLE"
+    return "$EX_OK"
+}
+
+cmd_version() {
+    local version="unknown" jar="$APP_DIR/app.jar" build="unknown"
+    if [[ -r "$APP_DIR/VERSION" ]]; then
+        version="$(sed -n '1p' "$APP_DIR/VERSION" | tr -d '\r\n')"
+    fi
+    if [[ -f "$jar" ]]; then
+        build="$(date -r "$jar" '+%Y-%m-%d %H:%M:%S %z' 2>/dev/null || echo unknown)"
+    fi
+    log "Moddex version: ${version:-unknown}"
+    log "Backend build:  $build"
+    log ""
+    log "Paths:"
+    log "  application: $APP_DIR"
+    log "  data:        $DATA_DIR"
+    log "  config:      $CONFIG_DIR (env: $ENV_FILE)"
+    log "  logs:        $LOG_DIR"
+}
+
+cmd_list_instances() {
+    ensure_token
+    local out status body
+    out="$(http_body_status GET /api/v1/instance -H "$(auth_header)")"
+    status="${out##*$'\n'}"
+    body="${out%$'\n'*}"
+    case "$status" in
+        200) ;;
+        000) die "$EX_UNREACHABLE" "backend unreachable at $(base_url)." ;;
+        401|403) die "$EX_AUTH" "not authorized (HTTP $status)." ;;
+        *)   die "$EX_ERR" "could not list instances (HTTP $status)." ;;
+    esac
+
+    if have_jq; then
+        local count
+        count="$(printf '%s' "$body" | jq 'length')"
+        if [[ "$count" -eq 0 ]]; then
+            log "No instances."
+            return "$EX_OK"
+        fi
+        printf '%-38s %s\n' "ID" "NAME"
+        printf '%s' "$body" | jq -r '.[] | "\(.id // "?")\t\(.name // "?")"' \
+            | while IFS=$'\t' read -r id name; do printf '%-38s %s\n' "$id" "$name"; done
+    else
+        log "Instances (install jq for formatted output):"
+        printf '%s\n' "$body"
+    fi
+}
+
+cmd_backup() {
+    local id="" type=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --type) [[ $# -ge 2 ]] || die "$EX_USAGE" "missing value for --type"; type="$2"; shift 2 ;;
+            -*) die "$EX_USAGE" "unknown option: $1" ;;
+            *) [[ -z "$id" ]] || die "$EX_USAGE" "unexpected argument: $1"; id="$1"; shift ;;
+        esac
+    done
+    [[ -n "$id" ]] || die "$EX_USAGE" "usage: moddex backup <instance-id> [--type standard|full]"
+    if [[ -n "$type" ]]; then
+        type="$(printf '%s' "$type" | tr '[:upper:]' '[:lower:]')"
+        case "$type" in standard|full) ;; *) die "$EX_USAGE" "invalid --type: $type (expected standard or full)" ;; esac
+    fi
+
+    ensure_token
+    local path="/api/v1/instance/${id}/backups"
+    [[ -n "$type" ]] && path="${path}?type=${type}"
+    local status
+    status="$(http_status POST "$path" -H "$(auth_header)")"
+    case "$status" in
+        200|201) log "Backup created for instance $id${type:+ (type: $type)}." ;;
+        000) die "$EX_UNREACHABLE" "backend unreachable at $(base_url)." ;;
+        401|403) die "$EX_AUTH" "not authorized (HTTP $status)." ;;
+        404) die "$EX_ERR" "instance not found: $id" ;;
+        *)   die "$EX_ERR" "backup failed (HTTP $status)." ;;
+    esac
+}
+
+cmd_restore() {
+    local id="" name="" assume_yes=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -y|--yes) assume_yes=1; shift ;;
+            -*) die "$EX_USAGE" "unknown option: $1" ;;
+            *)
+                if [[ -z "$id" ]]; then id="$1"
+                elif [[ -z "$name" ]]; then name="$1"
+                else die "$EX_USAGE" "unexpected argument: $1"; fi
+                shift ;;
+        esac
+    done
+    [[ -n "$id" && -n "$name" ]] || die "$EX_USAGE" "usage: moddex restore <instance-id> <backup-name> [--yes]"
+
+    # Restore overwrites the live instance state, so require explicit confirmation.
+    if [[ "$assume_yes" -ne 1 ]]; then
+        if [[ -t 0 ]]; then
+            printf 'Restore backup "%s" onto instance %s? This overwrites current state. [y/N] ' "$name" "$id" >&2
+            local ans; read -r ans
+            [[ "${ans,,}" == y* ]] || die "$EX_OK" "aborted."
+        else
+            die "$EX_USAGE" "refusing destructive restore without --yes in a non-interactive session."
+        fi
+    fi
+
+    ensure_token
+    local status
+    status="$(http_status POST "/api/v1/instance/${id}/backups/${name}/restore" -H "$(auth_header)")"
+    case "$status" in
+        200|204) log "Restore of \"$name\" onto instance $id completed." ;;
+        000) die "$EX_UNREACHABLE" "backend unreachable at $(base_url)." ;;
+        401|403) die "$EX_AUTH" "not authorized (HTTP $status)." ;;
+        404) die "$EX_ERR" "instance or backup not found ($id / $name)." ;;
+        400) die "$EX_ERR" "restore rejected: invalid or corrupt backup (HTTP 400)." ;;
+        *)   die "$EX_ERR" "restore failed (HTTP $status)." ;;
+    esac
+}
+
+cmd_logs() {
+    local follow=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -f|--follow) follow=1; shift ;;
+            *) die "$EX_USAGE" "unknown option: $1" ;;
+        esac
+    done
+    local out="$LOG_DIR/backend.out.log"
+    [[ -r "$out" ]] || die "$EX_ERR" "log file not readable: $out (need root?)"
+    if [[ "$follow" -eq 1 ]]; then
+        tail -f "$out"
+    else
+        tail -n 200 "$out"
+    fi
+}
+
+usage() {
+    cat <<'USAGE'
+moddex - administrative CLI for a native Moddex installation
+
+Usage: moddex <command> [options]
+
+Service commands:
+  status                  Show service state, endpoint and reachability
+  start                   Start the Moddex backend service
+  stop                    Stop the Moddex backend service
+  restart                 Restart the Moddex backend service
+  version                 Show version, build date and installation paths
+
+Instance commands (require API authentication):
+  list-instances          List configured instances (id and name)
+  backup <id> [--type standard|full]
+                          Create a backup for an instance
+  restore <id> <name> [--yes]
+                          Restore a backup onto an instance (destructive)
+
+Other:
+  logs [--follow]         Show the backend log (last 200 lines, -f to follow)
+  help                    Show this help
+
+Authentication (instance commands):
+  Provide a token via --token / MODDEX_API_TOKEN, or a password via
+  MODDEX_ADMIN_PASSWORD. Without either, the CLI prompts interactively.
+
+Connection:
+  Reads SERVER_ADDRESS / SERVER_PORT from /etc/moddex/moddex.env. A wildcard
+  bind is contacted on 127.0.0.1.
+
+Exit codes:
+  0 success   1 error   2 usage   3 service   4 auth   5 unreachable   6 dependency
+USAGE
+}
+
+# ---------------------------------------------------------------------------
+# Argument dispatch
+# ---------------------------------------------------------------------------
+
+main() {
+    [[ $# -ge 1 ]] || { usage >&2; exit "$EX_USAGE"; }
+
+    local cmd="$1"; shift
+
+    # A global --token flag is accepted anywhere after the command; everything
+    # else is forwarded to the command handler.
+    local rest=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --token) [[ $# -ge 2 ]] || die "$EX_USAGE" "missing value for --token"; TOKEN="$2"; shift 2 ;;
+            *) rest+=("$1"); shift ;;
+        esac
+    done
+    set -- "${rest[@]+"${rest[@]}"}"
+
+    case "$cmd" in
+        status)          cmd_status ;;
+        start)           service_action start ;;
+        stop)            service_action stop ;;
+        restart)         service_action restart ;;
+        version|--version|-V) cmd_version ;;
+        list-instances)  cmd_list_instances ;;
+        backup)          cmd_backup "$@" ;;
+        restore)         cmd_restore "$@" ;;
+        logs)            cmd_logs "$@" ;;
+        help|-h|--help)  usage ;;
+        *) err "unknown command: $cmd"; usage >&2; exit "$EX_USAGE" ;;
+    esac
+}
+
+main "$@"

--- a/scripts/moddex
+++ b/scripts/moddex
@@ -45,7 +45,11 @@ need_cmd() { command -v "$1" >/dev/null 2>&1 || die "$EX_DEP" "missing required 
 
 # Load SERVER_ADDRESS / SERVER_PORT from the machine-local env file if present.
 # Values already set in the environment win, so callers can override per-run.
+# Memoized: base_url() calls this on every request, but we only read/warn once.
+ENV_LOADED=0
 load_env() {
+    [[ "$ENV_LOADED" -eq 1 ]] && return 0
+    ENV_LOADED=1
     if [[ -r "$ENV_FILE" ]]; then
         local addr port
         # Read without polluting the current shell beyond what we extract.
@@ -53,6 +57,12 @@ load_env() {
         port="$(. "$ENV_FILE" 2>/dev/null; printf '%s' "${SERVER_PORT:-}")"
         [[ -z "${SERVER_ADDRESS:-}" && -n "$addr" ]] && SERVER_ADDRESS="$addr"
         [[ -z "${SERVER_PORT:-}" && -n "$port" ]] && SERVER_PORT="$port"
+    elif [[ -e "$ENV_FILE" && -z "${SERVER_ADDRESS:-}" && -z "${SERVER_PORT:-}" ]]; then
+        # The file exists but this user cannot read it (it is 0640 root:moddex).
+        # Warn instead of silently contacting the wrong endpoint on custom-port
+        # installs; root or members of the 'moddex' group get the real values.
+        err "warning: $ENV_FILE is not readable by this user; falling back to ${SERVER_ADDRESS:-127.0.0.1}:${SERVER_PORT:-8080}."
+        err "         Run via sudo, join the 'moddex' group, or set SERVER_ADDRESS/SERVER_PORT to target the configured endpoint."
     fi
     SERVER_PORT="${SERVER_PORT:-8080}"
     SERVER_ADDRESS="${SERVER_ADDRESS:-127.0.0.1}"

--- a/scripts/moddex
+++ b/scripts/moddex
@@ -57,27 +57,40 @@ load_env() {
         port="$(. "$ENV_FILE" 2>/dev/null; printf '%s' "${SERVER_PORT:-}")"
         [[ -z "${SERVER_ADDRESS:-}" && -n "$addr" ]] && SERVER_ADDRESS="$addr"
         [[ -z "${SERVER_PORT:-}" && -n "$port" ]] && SERVER_PORT="$port"
-    elif [[ -e "$ENV_FILE" && -z "${SERVER_ADDRESS:-}" && -z "${SERVER_PORT:-}" ]]; then
-        # The file exists but this user cannot read it (it is 0640 root:moddex).
-        # Warn instead of silently contacting the wrong endpoint on custom-port
-        # installs; root or members of the 'moddex' group get the real values.
-        err "warning: $ENV_FILE is not readable by this user; falling back to ${SERVER_ADDRESS:-127.0.0.1}:${SERVER_PORT:-8080}."
+    elif [[ -z "${SERVER_ADDRESS:-}" && -z "${SERVER_PORT:-}" && ( -e "$ENV_FILE" || -d "$CONFIG_DIR" ) ]]; then
+        # An install is present ($CONFIG_DIR exists) but this user cannot read the
+        # config: the file is 0640 root:moddex inside a 0750 root:moddex dir, so a
+        # non-root user outside the 'moddex' group can neither read nor even
+        # traverse to it (then -e is false too). Warn instead of silently
+        # contacting the wrong endpoint on custom-address/port installs.
+        err "warning: cannot read $ENV_FILE ($CONFIG_DIR may be inaccessible to this user); falling back to ${SERVER_ADDRESS:-127.0.0.1}:${SERVER_PORT:-8080}."
         err "         Run via sudo, join the 'moddex' group, or set SERVER_ADDRESS/SERVER_PORT to target the configured endpoint."
     fi
     SERVER_PORT="${SERVER_PORT:-8080}"
     SERVER_ADDRESS="${SERVER_ADDRESS:-127.0.0.1}"
 }
 
-# Base URL for API calls. A wildcard bind (0.0.0.0 / ::) is not connectable, so
-# the CLI always talks to loopback from the same host.
-base_url() {
+# Resolve the API base URL once, in the parent shell. base_url() is used inside
+# many $(...) command substitutions, each of which runs in a subshell where a
+# memoization flag would not persist; doing the work here keeps load_env (and its
+# one-time warning) to a single execution. A wildcard bind (0.0.0.0 / ::) is not
+# connectable, so the CLI always talks to loopback from the same host.
+BASE_URL=""
+CONN_INIT=0
+init_connection() {
+    [[ "$CONN_INIT" -eq 1 ]] && return 0
+    CONN_INIT=1
     load_env
     local host="$SERVER_ADDRESS"
     case "$host" in
         0.0.0.0|""|"::"|"[::]") host="127.0.0.1" ;;
     esac
-    printf 'http://%s:%s' "$host" "$SERVER_PORT"
+    BASE_URL="http://${host}:${SERVER_PORT}"
 }
+
+# Emits the resolved base URL. Callers must have run init_connection first
+# (every network command does); kept as a function so $(base_url) reads naturally.
+base_url() { printf '%s' "$BASE_URL"; }
 
 # ---------------------------------------------------------------------------
 # HTTP helpers
@@ -106,6 +119,7 @@ TOKEN="${MODDEX_API_TOKEN:-}"
 #   3. interactive password prompt -> login
 ensure_token() {
     need_cmd curl
+    init_connection
     [[ -n "$TOKEN" ]] && return 0
 
     local password="${MODDEX_ADMIN_PASSWORD:-}"
@@ -204,6 +218,7 @@ service_action() {
 
 cmd_status() {
     need_cmd systemctl
+    init_connection
     local active enabled
     active="$(systemctl is-active "$SERVICE" 2>/dev/null || true)"
     enabled="$(systemctl is-enabled "$SERVICE" 2>/dev/null || true)"
@@ -247,6 +262,7 @@ cmd_version() {
 }
 
 cmd_list_instances() {
+    init_connection
     ensure_token
     local out status body
     out="$(http_body_status GET /api/v1/instance -H "$(auth_header)")"

--- a/scripts/moddex
+++ b/scripts/moddex
@@ -26,6 +26,9 @@ readonly EX_UNREACHABLE=5
 readonly EX_DEP=6
 
 readonly SERVICE="moddex-backend.service"
+# World-readable (0644 root:root) systemd unit — a reliable "an install exists"
+# marker that any user can stat even when /etc/moddex (0750) is not traversable.
+readonly SERVICE_UNIT="/etc/systemd/system/${SERVICE}"
 
 # FHS layout - kept in lock-step with scripts/install.sh and the systemd unit.
 APP_DIR="${MODDEX_APP_DIR:-/opt/moddex}"
@@ -57,12 +60,14 @@ load_env() {
         port="$(. "$ENV_FILE" 2>/dev/null; printf '%s' "${SERVER_PORT:-}")"
         [[ -z "${SERVER_ADDRESS:-}" && -n "$addr" ]] && SERVER_ADDRESS="$addr"
         [[ -z "${SERVER_PORT:-}" && -n "$port" ]] && SERVER_PORT="$port"
-    elif [[ -z "${SERVER_ADDRESS:-}" && -z "${SERVER_PORT:-}" && ( -e "$ENV_FILE" || -d "$CONFIG_DIR" ) ]]; then
-        # An install is present ($CONFIG_DIR exists) but this user cannot read the
-        # config: the file is 0640 root:moddex inside a 0750 root:moddex dir, so a
-        # non-root user outside the 'moddex' group can neither read nor even
-        # traverse to it (then -e is false too). Warn instead of silently
-        # contacting the wrong endpoint on custom-address/port installs.
+    elif [[ -z "${SERVER_ADDRESS:-}" && -z "${SERVER_PORT:-}" && ( -e "$ENV_FILE" || -d "$CONFIG_DIR" || -e "$SERVICE_UNIT" ) ]]; then
+        # An install is present but this user cannot read the config: the file is
+        # 0640 root:moddex inside a 0750 root:moddex dir, so a non-root user
+        # outside the 'moddex' group can neither read nor traverse to it (then -e
+        # on the file, and even -d on the dir if /etc itself were restricted, can
+        # be false). The world-readable systemd unit is a reliable fallback
+        # marker. Warn instead of silently contacting the wrong endpoint on
+        # custom-address/port installs.
         err "warning: cannot read $ENV_FILE ($CONFIG_DIR may be inaccessible to this user); falling back to ${SERVER_ADDRESS:-127.0.0.1}:${SERVER_PORT:-8080}."
         err "         Run via sudo, join the 'moddex' group, or set SERVER_ADDRESS/SERVER_PORT to target the configured endpoint."
     fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -5,6 +5,8 @@ read -p "Are you sure you want to uninstall? [y/N] " a
 sudo systemctl disable --now moddex-backend || true
 sudo rm -f /etc/systemd/system/moddex-backend.service
 sudo systemctl daemon-reload || true
-sudo rm -rf /opt/moddex /var/lib/moddex /etc/moddex
+# Application, data, config, logs and the administrative CLI.
+sudo rm -rf /opt/moddex /var/lib/moddex /etc/moddex /var/log/moddex
+sudo rm -f /usr/local/bin/moddex
 sudo userdel moddex 2>/dev/null || true
 echo "Moddex removed."


### PR DESCRIPTION
Closes #19 and #20 (merge into `develop` does not auto-close — issues will be closed manually after merge).

## #20 — Linux CLI-Grundbefehle (`moddex`)
New `scripts/moddex`, installed to `/usr/local/bin/moddex`:
- **Service:** `status` (state + endpoint + reachability via the unauthenticated `/api/v1/setup/status`), `start` / `stop` / `restart` (systemctl, self-`sudo`), `version` (version + build date + paths), `logs [--follow]`.
- **Instance ops:** `list-instances`, `backup <id> [--type standard|full]`, `restore <id> <name> [--yes]` (destructive → confirmation required).
- **Stable, documented exit codes:** `0` ok · `1` error · `2` usage · `3` service · `4` auth · `5` unreachable · `6` dependency.
- **Auth:** `--token` / `MODDEX_API_TOKEN`, or `MODDEX_ADMIN_PASSWORD` login, or interactive prompt. Connection target from `/etc/moddex/moddex.env`; wildcard bind contacted on loopback. Uses `jq` when present, JSON fallback otherwise.

## #19 — Native Debian/Ubuntu installer, systemd, update-resistant paths
- **FHS layout:** `/opt/moddex`, `/var/lib/moddex`, `/etc/moddex`, `/var/log/moddex`.
- **Idempotent / update-resistant:** re-runs upgrade artifacts only; `/etc/moddex/moddex.env` and instance data are preserved. Mode/port reused from the env file. One-time migration of old `/var/lib/moddex/logs`.
- **Java runtime check** (>= 17), non-interactive guard (fails fast without `--mode` when no TTY), version recorded to `/opt/moddex/VERSION`.
- **Hardened systemd unit:** `ProtectSystem=strict`, `NoNewPrivileges`, `PrivateTmp`, restricted `ReadWritePaths`, `network-online.target` ordering, `EnvironmentFile=-/etc/moddex/moddex.env`.
- **uninstall.sh** removes the CLI and `/var/log/moddex`; new `.gitignore` excludes `build/`.

## Docs
README: updated path table + permissions, update-resistance note, full CLI reference with exit-code table, corrected (now fail-closed) CORS note, and a **Debian/Ubuntu install smoke-test** walkthrough (acceptance criteria for both stories).

## Testing
- `bash -n` on all touched scripts.
- CLI exercised against a mock backend: login → token → `list-instances`, `backup`, and every error branch (usage / auth / unreachable). All exit codes verified. systemctl-dependent paths are validated by argument parsing locally and run on the Linux target.