### PR TITLE
test(qa): release smoke test, checklist & CI smoke job (#24)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,98 @@
+name: smoke
+
+# Manual pre-release smoke test. Builds and boots the backend on loopback with a
+# throwaway data directory, then runs scripts/release-smoke-test.sh against it.
+# See docs/qa/release-checklist.md.
+#
+# Cross-repo checkout: Moddex-Backend is private, so set MODDEX_CHECKOUT_TOKEN
+# (see docs/ci.md). By default the instance-create + backup steps are skipped
+# (no network download); set the `full` input to true to include them.
+
+on:
+  workflow_dispatch:
+    inputs:
+      full:
+        description: 'Also run the instance-create + backup steps (downloads a server JAR)'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: moddex-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-22.04
+    env:
+      CHECKOUT_TOKEN: ${{ secrets.MODDEX_CHECKOUT_TOKEN || github.token }}
+      ADMIN_PASSWORD: Smoke-${{ github.run_id }}-Aa1
+      SERVER_ADDRESS: 127.0.0.1
+      SERVER_PORT: '8080'
+
+    steps:
+      - name: Checkout packaging repo (Moddex-build)
+        uses: actions/checkout@v4
+        with:
+          repository: aklozyp/Moddex
+          token: ${{ env.CHECKOUT_TOKEN }}
+          path: Moddex-build
+
+      - name: Checkout backend repo
+        uses: actions/checkout@v4
+        with:
+          repository: aklozyp/Moddex-Backend
+          ref: tests
+          token: ${{ env.CHECKOUT_TOKEN }}
+          path: Moddex-Backend
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build backend JAR
+        run: |
+          chmod +x Moddex-Backend/mvnw
+          Moddex-Backend/mvnw -f Moddex-Backend/pom.xml -B -Pprod -DskipTests clean package
+
+      - name: Boot backend on loopback
+        env:
+          MODDEX_ROOT: ${{ runner.temp }}/moddex-data
+          MODDEX_CONFIG_DIR: ${{ runner.temp }}/moddex-cfg
+          MODDEX_LOG_DIR: ${{ runner.temp }}/moddex-log
+          MODDEX_SECURITY_MODE: local
+        run: |
+          mkdir -p "$MODDEX_ROOT" "$MODDEX_CONFIG_DIR" "$MODDEX_LOG_DIR"
+          jar="$(find Moddex-Backend/target -maxdepth 1 -name 'Moddex-Backend-*.jar' | head -n1)"
+          [ -n "$jar" ] || { echo "backend JAR not found" >&2; exit 1; }
+          nohup java -jar "$jar" > "$MODDEX_LOG_DIR/boot.log" 2>&1 &
+          echo $! > backend.pid
+          echo "Waiting for backend readiness..."
+          for i in $(seq 1 60); do
+            code="$(curl -s -o /dev/null -w '%{http_code}' "http://${SERVER_ADDRESS}:${SERVER_PORT}/api/v1/setup/status" || true)"
+            if [ "$code" != "000" ] && [ -n "$code" ]; then echo "ready (HTTP $code) after ${i}s"; exit 0; fi
+            sleep 1
+          done
+          echo "backend did not become ready in time" >&2
+          tail -n 100 "$MODDEX_LOG_DIR/boot.log" >&2 || true
+          exit 1
+
+      - name: Run release smoke test
+        env:
+          BASE_URL: http://127.0.0.1:8080
+          MODDEX_ADMIN_PASSWORD: ${{ env.ADMIN_PASSWORD }}
+        run: |
+          chmod +x Moddex-build/scripts/release-smoke-test.sh
+          if [ "${{ inputs.full }}" = "true" ]; then
+            Moddex-build/scripts/release-smoke-test.sh
+          else
+            Moddex-build/scripts/release-smoke-test.sh --skip-instance
+          fi
+
+      - name: Stop backend
+        if: always()
+        run: |
+          if [ -f backend.pid ]; then kill "$(cat backend.pid)" 2>/dev/null || true; fi

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
         type: boolean
+      backend_ref:
+        description: 'Moddex-Backend ref to build & test (branch, tag or SHA). Set to the release candidate when gating a release.'
+        required: false
+        default: tests
+        type: string
 
 concurrency:
   group: moddex-smoke-${{ github.ref }}
@@ -42,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: aklozyp/Moddex-Backend
-          ref: tests
+          ref: ${{ inputs.backend_ref }}
           token: ${{ env.CHECKOUT_TOKEN }}
           path: Moddex-Backend
 

--- a/README.md
+++ b/README.md
@@ -393,6 +393,16 @@ and file operations cannot silently destroy instances:
   BASE_URL=http://127.0.0.1:8080 TOKEN=<jwt> INSTANCE_ID=<uuid> \
     scripts/smoke-test.sh            # add --with-restore for the destructive restore step
   ```
+- **Release smoke test:** [`scripts/release-smoke-test.sh`](scripts/release-smoke-test.sh)
+  and the [release checklist](docs/qa/release-checklist.md) — the v0.2 release
+  gate covering install → setup → login → create instance → backup → service
+  health, with stable exit codes. A manual `smoke.yml` GitHub Actions job boots a
+  throwaway backend and runs it:
+
+  ```bash
+  MODDEX_ADMIN_PASSWORD='<strong-password>' scripts/release-smoke-test.sh
+  # add --skip-instance for an offline run (no server-JAR download)
+  ```
 
 ### Debian/Ubuntu install smoke test
 

--- a/docs/qa/release-checklist.md
+++ b/docs/qa/release-checklist.md
@@ -38,6 +38,9 @@ test on the target host.
 
 ## Running the automated smoke test
 
+Prerequisites on the machine running the script: `curl` and a JSON encoder
+(`jq` **or** `python3`, used to safely encode the admin password).
+
 Against a running backend (defaults to `http://127.0.0.1:8080`):
 
 ```bash

--- a/docs/qa/release-checklist.md
+++ b/docs/qa/release-checklist.md
@@ -1,0 +1,101 @@
+# Release smoke test & checklist (v0.2)
+
+Before publishing a v0.2 release, the critical end-to-end flow must pass so that
+installer or core-flow regressions are caught **before** users hit them.
+
+The flow is: **install → first-run setup → login → create instance →
+create backup → service healthy.**
+
+Most of it is automated by [`scripts/release-smoke-test.sh`](../../scripts/release-smoke-test.sh);
+the native install step is exercised by the
+[Debian/Ubuntu install smoke test](../../README.md#debianubuntu-install-smoke-test)
+in the README. The deeper data-safety matrix lives in
+[`recovery-checklist.md`](recovery-checklist.md), and focused backup/restore/mod
+endpoint checks in [`scripts/smoke-test.sh`](../../scripts/smoke-test.sh).
+
+## Test environment
+
+A clean Debian 12 / Ubuntu 22.04+ host, VM or container (or a CI runner — see
+*CI* below). Requirements: `systemd`, OpenJDK 17+, network access (the
+instance-create step downloads a Minecraft server JAR).
+
+## Scenario
+
+| # | Step | How | Expected |
+|---|------|-----|----------|
+| 1 | Install natively | `sudo ./scripts/install.sh --mode local --port 8080` | exit `0`; `moddex status` → `Active: active`; unit enabled |
+| 2 | Service reachable | `moddex status` / `GET /api/v1/setup/status` | reachable; HTTP `200` |
+| 3 | Auth enforced (pre-setup/anon) | `curl -i .../api/v1/instance` | `401 Unauthorized` |
+| 4 | First-run setup | `POST /api/v1/setup/complete {password}` | `200`; `setupRequired` → `false` |
+| 5 | Login | `POST /api/v1/auth/login {password}` | `200` + bearer token |
+| 6 | Create instance | `POST /api/v1/instance {name,gameVersion,modLoader}` | `200`/`201`; server JAR downloaded; instance retrievable |
+| 7 | Create backup | `POST /api/v1/instance/{id}/backups?type=full` | `200`/`201` |
+| 8 | Service still healthy | `moddex status`; `systemctl status moddex-backend` | `Active: active`; no crash loop in logs |
+
+Steps 2–8 are automated by `release-smoke-test.sh`. Step 1 (the real installer)
+and step 8 (systemd health) are verified with the CLI / README install smoke
+test on the target host.
+
+## Running the automated smoke test
+
+Against a running backend (defaults to `http://127.0.0.1:8080`):
+
+```bash
+# Fresh backend: the script completes setup with the given password.
+MODDEX_ADMIN_PASSWORD='ChooseAStrongPassword' \
+  scripts/release-smoke-test.sh
+
+# Offline / quick (skip the network-dependent instance + backup steps):
+MODDEX_ADMIN_PASSWORD='...' scripts/release-smoke-test.sh --skip-instance
+
+# Override the test instance target:
+GAME_VERSION=1.21.1 MOD_LOADER=VANILLA MODDEX_ADMIN_PASSWORD='...' \
+  scripts/release-smoke-test.sh
+```
+
+On an already-set-up backend, `MODDEX_ADMIN_PASSWORD` must match the existing
+admin password (login step). The script prints a `PASS`/`FAIL` line per step and
+a final `Result: N passed, M failed`.
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | all checked steps passed |
+| `1` | one or more checked steps failed |
+| `2` | usage / precondition error (e.g. `curl` missing) |
+| `5` | backend unreachable |
+
+### Expected logs
+
+- Backend (`/var/log/moddex/backend.out.log`): `Admin logged in` on step 5;
+  instance registration (`Instance id=… registered successfully`) on step 6.
+- A clean run shows **no** `INSTANCE_CRASH` / restart-loop entries and the
+  service stays `active` throughout.
+
+## Release checklist
+
+Tick every item before tagging a release:
+
+- [ ] `ci.yml` is green on the source branches (backend + frontend build/tests).
+- [ ] Fresh-host install (step 1) succeeds; `moddex status` healthy.
+- [ ] `release-smoke-test.sh` exits `0` (all steps) against the fresh install.
+- [ ] Anonymous access to a protected endpoint returns `401` (step 3).
+- [ ] `recovery-checklist.md` 🚫 (blocker) rows pass — no silent data loss on
+      restore / mod rollback / broken modpack / full disk.
+- [ ] Re-running the installer preserves `/etc/moddex/moddex.env` and instance
+      data (update-resistance).
+- [ ] Release notes list known limitations (experimental features, Arch/Windows
+      status).
+
+A release is **blocked** if any checked smoke step fails or any 🚫 recovery row
+regresses.
+
+## CI
+
+[`/.github/workflows/smoke.yml`](../../.github/workflows/smoke.yml) prepares this
+as a manual (`workflow_dispatch`) job: it builds and boots the backend on
+loopback with a throwaway data directory and runs `release-smoke-test.sh`. By
+default it runs with `--skip-instance` (no network download); set the `full`
+input to `true` to also exercise instance creation + backup. Run it as a
+pre-release gate.

--- a/scripts/release-smoke-test.sh
+++ b/scripts/release-smoke-test.sh
@@ -79,9 +79,25 @@ json_field() {  # json_field <key>  (reads stdin; first matching string value)
   fi
 }
 
+# Quote an arbitrary string as a JSON string literal so passwords containing
+# " \ newlines or other JSON-significant characters never produce an invalid
+# request body. Uses jq or python3 (both encode every case correctly); one of
+# them is required as a precondition (checked below) so we never fall back to a
+# lossy hand-rolled escape.
+json_string() {
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$1" | jq -Rs .
+  else
+    MODDEX_JSON_IN="$1" python3 -c 'import json,os; print(json.dumps(os.environ["MODDEX_JSON_IN"]))'
+  fi
+}
+
 auth_header() { printf 'Authorization: Bearer %s' "$TOKEN"; }
 
 command -v curl >/dev/null 2>&1 || { echo "curl is required" >&2; exit 2; }
+# A JSON encoder is required so passwords with special characters are sent safely.
+command -v jq >/dev/null 2>&1 || command -v python3 >/dev/null 2>&1 || {
+  echo "jq or python3 is required (to safely JSON-encode the admin password)" >&2; exit 2; }
 
 log "Target: $BASE_URL"
 
@@ -99,15 +115,19 @@ fi
 status_body=$(http_body_status GET /api/v1/setup/status)
 setup_required=$(printf '%s' "${status_body%$'\n'*}" | grep -o '"setupRequired"[^,}]*' | grep -o 'true\|false' | head -n1)
 if [[ "$setup_required" == "true" ]]; then
-  complete=$(printf '{"password":"%s"}' "$ADMIN_PASSWORD" \
+  complete=$(printf '{"password":%s}' "$(json_string "$ADMIN_PASSWORD")" \
     | http_status POST /api/v1/setup/complete -H 'Content-Type: application/json' --data @-)
   if [[ "$complete" == "200" ]]; then
     ok "first-run setup completed (POST /setup/complete -> 200)"
   else
     bad "first-run setup failed (POST /setup/complete -> $complete)"
   fi
-else
+elif [[ "$setup_required" == "false" ]]; then
   ok "setup already completed (using provided admin password for login)"
+else
+  # Could not read setupRequired — the endpoint is broken or changed shape.
+  # Do not silently pass; the checklist requires a valid setup-status response.
+  bad "could not parse /setup/status response (setupRequired missing/unrecognized)"
 fi
 
 # --- 3. Auth enforcement ---------------------------------------------------
@@ -119,7 +139,7 @@ else
 fi
 
 # --- 4. Login --------------------------------------------------------------
-login_out=$(printf '{"password":"%s"}' "$ADMIN_PASSWORD" \
+login_out=$(printf '{"password":%s}' "$(json_string "$ADMIN_PASSWORD")" \
   | http_body_status POST /api/v1/auth/login -H 'Content-Type: application/json' --data @-)
 login_code="${login_out##*$'\n'}"
 TOKEN=$(printf '%s' "${login_out%$'\n'*}" | json_field token)

--- a/scripts/release-smoke-test.sh
+++ b/scripts/release-smoke-test.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#
+# Moddex release smoke test.
+#
+# End-to-end check of the critical v0.2 flow against a running backend:
+#   reachability -> first-run setup -> auth enforcement -> login ->
+#   create instance (downloads the server) -> create backup -> cleanup.
+#
+# This is the gate described in docs/qa/release-checklist.md. It complements
+# scripts/smoke-test.sh (focused backup/restore/mod checks) by also covering the
+# setup, login and instance-creation steps a fresh release must survive.
+#
+# Usage:
+#   BASE_URL=http://127.0.0.1:8080 MODDEX_ADMIN_PASSWORD='<pw>' \
+#     scripts/release-smoke-test.sh [--skip-instance]
+#
+# Environment:
+#   BASE_URL              Backend base URL (default: http://127.0.0.1:8080)
+#   MODDEX_ADMIN_PASSWORD Admin password. On a fresh backend this completes the
+#                         setup; on an already-set-up backend it must match the
+#                         existing admin password. (default: a generated value,
+#                         only useful on a fresh instance.)
+#   GAME_VERSION          Minecraft version for the test instance (default: 1.21.1)
+#   MOD_LOADER            Loader for the test instance (default: VANILLA)
+#
+# Flags:
+#   --skip-instance   Skip the instance-create + backup + cleanup steps (use when
+#                     the runner has no network to download a server JAR).
+#   -h, --help        Show this help.
+#
+# Exit codes (stable):
+#   0  all checked steps passed
+#   1  one or more checked steps failed
+#   2  usage / precondition error
+#   5  backend unreachable
+#
+set -uo pipefail
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:8080}"
+ADMIN_PASSWORD="${MODDEX_ADMIN_PASSWORD:-Smoke-$(date +%s)-Aa1}"
+GAME_VERSION="${GAME_VERSION:-1.21.1}"
+MOD_LOADER="${MOD_LOADER:-VANILLA}"
+SKIP_INSTANCE=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --skip-instance) SKIP_INSTANCE=1 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+pass=0
+fail=0
+TOKEN=""
+
+log()  { printf '[release-smoke] %s\n' "$*"; }
+ok()   { printf '  \033[32mPASS\033[0m %s\n' "$*"; pass=$((pass + 1)); }
+bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$*"; fail=$((fail + 1)); }
+
+# HTTP status only. curl's connect failure is swallowed so the script can report
+# "unreachable" itself instead of aborting; 000 means no response.
+http_status() {
+  local method="$1" path="$2"; shift 2
+  curl -s -o /dev/null -w '%{http_code}' -X "$method" "$@" "${BASE_URL}${path}" 2>/dev/null || true
+}
+
+# Body + trailing status line.
+http_body_status() {
+  local method="$1" path="$2"; shift 2
+  curl -s -w '\n%{http_code}' -X "$method" "$@" "${BASE_URL}${path}" 2>/dev/null || true
+}
+
+json_field() {  # json_field <key>  (reads stdin; first matching string value)
+  if command -v jq >/dev/null 2>&1; then
+    jq -r --arg k "$1" '.[$k] // empty' 2>/dev/null
+  else
+    grep -o "\"$1\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -n1 | sed 's/.*:[[:space:]]*"//;s/"$//'
+  fi
+}
+
+auth_header() { printf 'Authorization: Bearer %s' "$TOKEN"; }
+
+command -v curl >/dev/null 2>&1 || { echo "curl is required" >&2; exit 2; }
+
+log "Target: $BASE_URL"
+
+# --- 1. Reachability -------------------------------------------------------
+code=$(http_status GET /api/v1/setup/status)
+if [[ "$code" != "000" && -n "$code" ]]; then
+  ok "backend reachable (/setup/status -> $code)"
+else
+  bad "backend not reachable (no HTTP response)"
+  log "Aborting: backend unreachable."
+  exit 5
+fi
+
+# --- 2. First-run setup (idempotent) --------------------------------------
+status_body=$(http_body_status GET /api/v1/setup/status)
+setup_required=$(printf '%s' "${status_body%$'\n'*}" | grep -o '"setupRequired"[^,}]*' | grep -o 'true\|false' | head -n1)
+if [[ "$setup_required" == "true" ]]; then
+  complete=$(printf '{"password":"%s"}' "$ADMIN_PASSWORD" \
+    | http_status POST /api/v1/setup/complete -H 'Content-Type: application/json' --data @-)
+  if [[ "$complete" == "200" ]]; then
+    ok "first-run setup completed (POST /setup/complete -> 200)"
+  else
+    bad "first-run setup failed (POST /setup/complete -> $complete)"
+  fi
+else
+  ok "setup already completed (using provided admin password for login)"
+fi
+
+# --- 3. Auth enforcement ---------------------------------------------------
+anon=$(http_status GET /api/v1/instance)
+if [[ "$anon" == "401" || "$anon" == "403" ]]; then
+  ok "protected endpoint rejects anonymous access (/instance -> $anon)"
+else
+  bad "protected endpoint not enforced (/instance -> $anon)"
+fi
+
+# --- 4. Login --------------------------------------------------------------
+login_out=$(printf '{"password":"%s"}' "$ADMIN_PASSWORD" \
+  | http_body_status POST /api/v1/auth/login -H 'Content-Type: application/json' --data @-)
+login_code="${login_out##*$'\n'}"
+TOKEN=$(printf '%s' "${login_out%$'\n'*}" | json_field token)
+if [[ "$login_code" == "200" && -n "$TOKEN" ]]; then
+  ok "admin login (POST /auth/login -> 200, token issued)"
+else
+  bad "admin login failed (POST /auth/login -> $login_code)"
+  log "Cannot continue authenticated checks without a token."
+  log "Result: $pass passed, $fail failed."
+  [[ "$fail" -eq 0 ]] && exit 0 || exit 1
+fi
+
+# --- 5. Authenticated instance list ---------------------------------------
+authed=$(http_status GET /api/v1/instance -H "$(auth_header)")
+if [[ "$authed" == "200" ]]; then
+  ok "authenticated instance list (/instance -> 200)"
+else
+  bad "authenticated instance list failed (/instance -> $authed)"
+fi
+
+# --- 6/7/8. Instance lifecycle + backup -----------------------------------
+if [[ "$SKIP_INSTANCE" -eq 1 ]]; then
+  log "Skipping instance create/backup steps (--skip-instance)."
+else
+  inst_name="smoke-$(date +%s)"
+  create_out=$(printf '{"name":"%s","gameVersion":"%s","modLoader":"%s"}' \
+      "$inst_name" "$GAME_VERSION" "$MOD_LOADER" \
+    | http_body_status POST /api/v1/instance -H 'Content-Type: application/json' -H "$(auth_header)" --data @-)
+  create_code="${create_out##*$'\n'}"
+  inst_id=$(printf '%s' "${create_out%$'\n'*}" | json_field id)
+  if [[ ( "$create_code" == "200" || "$create_code" == "201" ) && -n "$inst_id" ]]; then
+    ok "instance created (POST /instance -> $create_code, id=$inst_id)"
+  else
+    bad "instance creation failed (POST /instance -> $create_code) — needs network to download the server JAR"
+    inst_id=""
+  fi
+
+  if [[ -n "$inst_id" ]]; then
+    listed=$(http_status GET "/api/v1/instance/${inst_id}" -H "$(auth_header)")
+    if [[ "$listed" == "200" ]]; then
+      ok "instance retrievable (/instance/$inst_id -> 200)"
+    else
+      bad "instance not retrievable (/instance/$inst_id -> $listed)"
+    fi
+
+    backup=$(http_status POST "/api/v1/instance/${inst_id}/backups?type=full" -H "$(auth_header)")
+    if [[ "$backup" == "200" || "$backup" == "201" ]]; then
+      ok "backup created (POST /backups?type=full -> $backup)"
+    else
+      bad "backup creation failed (POST /backups -> $backup)"
+    fi
+
+    # Cleanup is best-effort and not counted as a checked step.
+    cleanup=$(http_status DELETE "/api/v1/instance/${inst_id}" -H "$(auth_header)")
+    log "cleanup: deleted test instance (/instance/$inst_id -> $cleanup)"
+  fi
+fi
+
+log "Result: $pass passed, $fail failed."
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Closes #24 (merge into `develop` does not auto-close — closed manually after merge).

Defines the v0.2 release gate: **install → setup → login → create instance → backup → service health.**

## Changes
- **`scripts/release-smoke-test.sh`:** end-to-end check against a running backend — reachability, idempotent first-run setup, auth enforcement, login, instance create (downloads the server JAR), retrieve, full backup, and cleanup. Stable exit codes (`0`/`1`/`2`/`5`), per-step PASS/FAIL report. `--skip-instance` runs the network-free subset.
- **`docs/qa/release-checklist.md`:** the defined scenario, expected status codes/logs, how to run it, and a pre-release checklist that blocks on any failed step or a regressed recovery-checklist 🚫 row.
- **`.github/workflows/smoke.yml`:** manual `workflow_dispatch` job that builds and boots the backend on loopback with a throwaway data dir and runs the script (skips the instance step unless the `full` input is set).
- README QA section links the release smoke test and checklist.

## Tasks (issue #24)
- [x] Smoke-Test-Szenario definiert (install/setup/login/instance/backup/service)
- [x] Testumgebung für Ubuntu/Debian beschrieben + automatisiert (script + CI job)
- [x] Erwartete Logs/Exit-Codes dokumentiert
- [x] Release-Checklist erstellt
- [x] Smoke-Test in GitHub Actions vorbereitet (workflow_dispatch, soweit praktikabel)

## Testing
Validated the script end-to-end against a mock backend: full flow (8/8 pass, exit 0), already-set-up re-run with `--skip-instance` (5/5, exit 0), and unreachable (exit 5). Both `smoke.yml` and the script validated (YAML + `bash -n`). The live CI boot is `workflow_dispatch` and requires the `MODDEX_CHECKOUT_TOKEN` secret.