### PR TITLE
feat(windows): PowerShell installer, WinSW service, CI artifact and docs (#26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,9 @@ name: ci
 #
 # Target matrix: ubuntu-22.04 and ubuntu-24.04 cover the glibc range of the
 # supported Debian/Ubuntu targets. Arch Linux has no GitHub-hosted runner and is
-# treated as experimental (documented in docs/ci.md). Windows packaging is a
-# v0.3 target (epic #26) and intentionally does not gate v0.2.
+# treated as experimental (documented in docs/ci.md). Windows packaging (v0.3,
+# epic #26) is assembled by the separate `build-windows` job below on a Windows
+# runner; it runs independently and does not gate the Linux build.
 
 on:
   push:
@@ -100,5 +101,67 @@ jobs:
           path: |
             Moddex-build/build/moddex-*-linux-amd64.tar.gz
             Moddex-build/build/moddex-*-linux-amd64.tar.gz.sha256
+          if-no-files-found: error
+          retention-days: 14
+
+  # Windows packaging (v0.3 target, epic #26). Assembles the installable Windows
+  # artifact so the PowerShell installer/service path is exercised on every change.
+  # Runs independently on a Windows runner; it does not gate the Linux build.
+  build-windows:
+    runs-on: windows-2022
+    env:
+      CHECKOUT_TOKEN: ${{ secrets.MODDEX_CHECKOUT_TOKEN || github.token }}
+      VERSION: ci-${{ github.run_number }}-windows
+
+    steps:
+      - name: Checkout packaging repo (Moddex-build)
+        uses: actions/checkout@v4
+        with:
+          repository: aklozyp/Moddex
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          token: ${{ env.CHECKOUT_TOKEN }}
+          path: Moddex-build
+
+      - name: Checkout backend repo
+        uses: actions/checkout@v4
+        with:
+          repository: aklozyp/Moddex-Backend
+          ref: tests
+          token: ${{ env.CHECKOUT_TOKEN }}
+          path: Moddex-Backend
+
+      - name: Checkout frontend repo
+        uses: actions/checkout@v4
+        with:
+          repository: aklozyp/Moddex-Frontend
+          ref: tests
+          token: ${{ env.CHECKOUT_TOKEN }}
+          path: Moddex-Frontend
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'Moddex-Frontend/package-lock.json'
+
+      - name: Assemble Windows bundle
+        shell: pwsh
+        run: Moddex-build/scripts/windows/build-bundle.ps1 -Version $env:VERSION
+
+      - name: Upload Windows bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: moddex-bundle-windows
+          path: |
+            Moddex-build/build/moddex-*-windows-x64.zip
+            Moddex-build/build/moddex-*-windows-x64.zip.sha256
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,3 +113,79 @@ jobs:
             moddex-${{ env.TARGET_REF }}-linux-amd64.tar.gz.sha256
             download.sh
             download.sh.sha256
+
+  # Windows artifact (v0.3, epic #26). Runs after the Linux release exists and
+  # appends the installable Windows zip + checksum to the same GitHub Release.
+  build-package-windows:
+    needs: build-package
+    runs-on: windows-2022
+    permissions:
+      contents: write   # required for release upload
+    env:
+      TARGET_REF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+      CHECKOUT_TOKEN: ${{ secrets.MODDEX_CHECKOUT_TOKEN || github.token }}
+
+    steps:
+      - name: Checkout packaging repo (Moddex-build)
+        uses: actions/checkout@v4
+        with:
+          repository: aklozyp/Moddex
+          ref: ${{ env.TARGET_REF }}
+          token: ${{ env.CHECKOUT_TOKEN }}
+          path: Moddex-build
+
+      - name: Checkout backend repo
+        uses: actions/checkout@v4
+        with:
+          repository: aklozyp/Moddex-Backend
+          ref: ${{ env.TARGET_REF }}
+          token: ${{ env.CHECKOUT_TOKEN }}
+          path: Moddex-Backend
+
+      - name: Checkout frontend repo
+        uses: actions/checkout@v4
+        with:
+          repository: aklozyp/Moddex-Frontend
+          ref: ${{ env.TARGET_REF }}
+          token: ${{ env.CHECKOUT_TOKEN }}
+          path: Moddex-Frontend
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'Moddex-Frontend/package-lock.json'
+
+      - name: Build Windows bundle
+        shell: pwsh
+        run: Moddex-build/scripts/windows/build-bundle.ps1 -Version $env:TARGET_REF
+
+      - name: Verify checksum
+        shell: pwsh
+        run: |
+          $zip = "Moddex-build/build/moddex-$env:TARGET_REF-windows-x64.zip"
+          $expected = (Get-Content "$zip.sha256").Split(' ')[0]
+          $actual = (Get-FileHash -Algorithm SHA256 -Path $zip).Hash.ToLowerInvariant()
+          if ($actual -ne $expected) { throw "Checksum mismatch: $actual != $expected" }
+
+      - name: Stage release artifacts
+        shell: pwsh
+        run: |
+          Copy-Item "Moddex-build/build/moddex-$env:TARGET_REF-windows-x64.zip" .
+          Copy-Item "Moddex-build/build/moddex-$env:TARGET_REF-windows-x64.zip.sha256" .
+
+      - name: Attach to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TARGET_REF }}
+          files: |
+            moddex-${{ env.TARGET_REF }}-windows-x64.zip
+            moddex-${{ env.TARGET_REF }}-windows-x64.zip.sha256

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Legend: ✅ available · 🧪 experimental/unvalidated · — not yet / out of s
 |----------|--------|-------|
 | Debian 12 / Ubuntu 22.04+ | **Supported** | Primary target; native installer + systemd. |
 | Arch Linux | **Experimental** | Expected to work (systemd, OpenJDK 17+) but not validated in CI. |
-| Windows | Planned (v0.3) | Installer is a v0.3 target ([#26](https://github.com/aklozyp/Moddex/issues/26)); not a v0.2 blocker. |
+| Windows 10/11, Server 2019+ | **Supported (v0.3)** | PowerShell installer + Windows service (WinSW). See [Windows](#windows). |
 | Docker | Dev utility only | The `Docker/` files in the meta repo are for local development. Docker is **not** the supported production deployment path — install natively per below. |
 
 ## Installation
@@ -99,6 +99,48 @@ The installer prompts for the deployment mode during execution.
    ```bash
    sudo ./scripts/install.sh
    ```
+
+### Windows
+
+Windows is installed from the dedicated `moddex-<tag>-windows-x64.zip` artifact and runs the
+backend as a Windows service via [WinSW](https://github.com/winsw/winsw). Java 17+ must be on the
+`PATH` (or reachable via `JAVA_HOME`).
+
+Path layout:
+
+| Purpose | Location |
+|---------|----------|
+| Application (`app.jar`, frontend, service wrapper) | `%ProgramFiles%\Moddex` |
+| Instance data (`MODDEX_ROOT`) | `%ProgramData%\Moddex\data` |
+| Config | `%ProgramData%\Moddex\config` |
+| Logs | `%ProgramData%\Moddex\logs` |
+
+Install from an **elevated** PowerShell session:
+
+```powershell
+$Tag = 'v0.1.0'
+Invoke-WebRequest "https://github.com/aklozyp/Moddex/releases/download/$Tag/moddex-$Tag-windows-x64.zip" -OutFile moddex.zip
+Invoke-WebRequest "https://github.com/aklozyp/Moddex/releases/download/$Tag/moddex-$Tag-windows-x64.zip.sha256" -OutFile moddex.zip.sha256
+# Verify the checksum
+$expected = (Get-Content moddex.zip.sha256).Split(' ')[0]
+if ((Get-FileHash moddex.zip).Hash.ToLower() -ne $expected) { throw 'Checksum mismatch' }
+Expand-Archive moddex.zip -DestinationPath moddex-$Tag
+# Install and register the service (defaults: local mode, port 8080)
+.\moddex-$Tag\scripts\windows\install.ps1 -Mode local
+```
+
+The installer is idempotent: re-running it upgrades `app.jar` and the frontend without touching
+instance data, and preserves the machine-local mode/port unless you pass `-Mode`/`-Port` again. The
+bundled WinSW binary is checksum-pinned; the installer rejects a mismatched download.
+
+Manage the service with standard tooling:
+
+```powershell
+Get-Service moddex-backend            # status
+Restart-Service moddex-backend        # restart
+& "$env:ProgramFiles\Moddex\moddex-backend.exe" status   # WinSW status/logs
+.\scripts\windows\uninstall.ps1        # remove (add -Purge to also delete data)
+```
 
 ## Installer Options
 

--- a/packaging/windows/moddex-backend.xml.template
+++ b/packaging/windows/moddex-backend.xml.template
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  WinSW service definition for the Moddex backend on Windows.
+
+  install.ps1 renders this template into %ProgramFiles%\Moddex\moddex-backend.xml,
+  substituting the @@PLACEHOLDERS@@ with the resolved install paths and the
+  machine-local mode/port. The rendered file is the single source of machine-local
+  runtime configuration on Windows (the counterpart of /etc/moddex/moddex.env on
+  Linux); a re-install preserves its existing <env> values unless -Mode/-Port is
+  passed explicitly, so unattended upgrades stay non-destructive.
+
+  The env var names match what the backend reads (see the systemd unit and
+  application.yml): MODDEX_ROOT / MODDEX_CONFIG_DIR / MODDEX_LOG_DIR / MODDEX_MODE
+  and SERVER_ADDRESS / SERVER_PORT.
+-->
+<service>
+  <id>moddex-backend</id>
+  <name>Moddex Backend</name>
+  <description>Moddex Backend API (Minecraft server manager)</description>
+
+  <!-- Resolved from the system PATH at install time; falls back to JAVA_HOME. -->
+  <executable>@@JAVA_EXE@@</executable>
+  <arguments>-jar "@@APP_DIR@@\app.jar"</arguments>
+  <workingdirectory>@@APP_DIR@@</workingdirectory>
+
+  <!-- Machine-local runtime configuration (mode/bind/port + data paths). -->
+  <env name="MODDEX_ROOT" value="@@DATA_DIR@@" />
+  <env name="MODDEX_CONFIG_DIR" value="@@CONFIG_DIR@@" />
+  <env name="MODDEX_LOG_DIR" value="@@LOG_DIR@@" />
+  <env name="MODDEX_MODE" value="@@MODE@@" />
+  <env name="SERVER_ADDRESS" value="@@SERVER_ADDRESS@@" />
+  <env name="SERVER_PORT" value="@@SERVER_PORT@@" />
+
+  <!-- Restart on crash, but treat a clean shutdown as success. -->
+  <onfailure action="restart" delay="5 sec" />
+  <resetfailure>1 hour</resetfailure>
+  <stoptimeout>20 sec</stoptimeout>
+
+  <!-- Roll logs by size so the service does not fill the disk over time. -->
+  <log mode="roll-by-size">
+    <logpath>@@LOG_DIR@@</logpath>
+    <sizeThreshold>10240</sizeThreshold>
+    <keepFiles>8</keepFiles>
+  </log>
+
+  <startmode>Automatic</startmode>
+</service>

--- a/packaging/windows/moddex-backend.xml.template
+++ b/packaging/windows/moddex-backend.xml.template
@@ -28,6 +28,9 @@
   <env name="MODDEX_CONFIG_DIR" value="@@CONFIG_DIR@@" />
   <env name="MODDEX_LOG_DIR" value="@@LOG_DIR@@" />
   <env name="MODDEX_MODE" value="@@MODE@@" />
+  <!-- Drives the backend's CORS/security policy (moddex.security.mode); must match
+       MODDEX_MODE so a lan/public install does not run with the local default. -->
+  <env name="MODDEX_SECURITY_MODE" value="@@MODE@@" />
   <env name="SERVER_ADDRESS" value="@@SERVER_ADDRESS@@" />
   <env name="SERVER_PORT" value="@@SERVER_PORT@@" />
 

--- a/scripts/windows/build-bundle.ps1
+++ b/scripts/windows/build-bundle.ps1
@@ -82,6 +82,10 @@ Copy-Item -Path (Join-Path $frontendDist '*') -Destination (Join-Path $BundleDir
 
 # --- installer resources -----------------------------------------------------
 Write-Log 'Copying Windows installer resources'
+# Create the intermediate parents first: Copy-Item -Recurse does not reliably
+# create missing parent directories of the destination across PowerShell versions.
+New-Item -ItemType Directory -Force -Path (Join-Path $BundleDir 'scripts') | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $BundleDir 'packaging') | Out-Null
 Copy-Item -Path (Join-Path $ProjectRoot 'scripts\windows') -Destination (Join-Path $BundleDir 'scripts\windows') -Recurse -Force
 Copy-Item -Path (Join-Path $ProjectRoot 'packaging\windows') -Destination (Join-Path $BundleDir 'packaging\windows') -Recurse -Force
 

--- a/scripts/windows/build-bundle.ps1
+++ b/scripts/windows/build-bundle.ps1
@@ -1,0 +1,122 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Assembles the installable Moddex Windows artifact (zip + SHA256).
+
+.DESCRIPTION
+    The Windows counterpart of scripts/build-bundle.sh. Builds the backend JAR and
+    the production frontend from the sibling Moddex-Backend / Moddex-Frontend
+    repositories, bundles the Windows installer scripts and the verified WinSW
+    service wrapper, and produces moddex-<version>-windows-x64.zip with a checksum.
+
+.PARAMETER Version
+    Version label embedded in the artifact name and VERSION file (default: dev).
+#>
+[CmdletBinding()]
+param(
+    [string]$Version = $(if ($env:VERSION) { $env:VERSION } else { 'dev' })
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir   = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent (Split-Path -Parent $ScriptDir)   # scripts\windows -> repo root
+$RepoRoot    = Split-Path -Parent $ProjectRoot
+$BackendDir  = Join-Path $RepoRoot 'Moddex-Backend'
+$FrontendDir = Join-Path $RepoRoot 'Moddex-Frontend'
+
+$BuildDir    = Join-Path $ProjectRoot 'build'
+$BundleDir   = Join-Path $BuildDir 'bundle-windows'
+
+# Keep the WinSW pin in sync with install.ps1.
+$WinSwVersion = 'v2.12.0'
+$WinSwUrl     = "https://github.com/winsw/winsw/releases/download/$WinSwVersion/WinSW-x64.exe"
+$WinSwSha256  = '05b82d46ad331cc16bdc00de5c6332c1ef818df8ceefcd49c726553209b3a0da'
+
+function Write-Log([string]$Message) { Write-Host "[build] $Message" }
+function Die([string]$Message) { Write-Error $Message; exit 1 }
+
+# Runs a native command (npm/mvnw) robustly. Tools like npm print warnings to
+# stderr; under $ErrorActionPreference='Stop' Windows PowerShell would turn that
+# into a terminating NativeCommandError even on a successful run. Drop to
+# 'Continue' for the call (do NOT redirect stderr, which would wrap each line as
+# an ErrorRecord) and decide success solely from the process exit code.
+function Invoke-Native {
+    param([Parameter(Mandatory)][scriptblock]$Cmd, [Parameter(Mandatory)][string]$What)
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try { & $Cmd } finally { $ErrorActionPreference = $prev }
+    if ($LASTEXITCODE -ne 0) { Die "$What failed (exit $LASTEXITCODE)" }
+}
+
+if (Test-Path $BuildDir) { Remove-Item -Recurse -Force $BuildDir }
+New-Item -ItemType Directory -Force -Path (Join-Path $BundleDir 'backend') | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $BundleDir 'frontend') | Out-Null
+
+# --- backend -----------------------------------------------------------------
+if (-not (Test-Path (Join-Path $BackendDir 'pom.xml'))) { Die "Backend project not found at $BackendDir" }
+Write-Log 'Building backend artifact'
+$mvnw = Join-Path $BackendDir 'mvnw.cmd'
+Invoke-Native { & $mvnw -f (Join-Path $BackendDir 'pom.xml') -B -Pprod -DskipTests clean package } 'Backend build'
+$backendJar = Get-ChildItem -Path (Join-Path $BackendDir 'target') -Filter 'Moddex-Backend-*.jar' |
+    Where-Object { $_.Name -notmatch 'sources|javadoc' } | Select-Object -First 1
+if (-not $backendJar) { Die "Backend JAR not found in $BackendDir\target" }
+Copy-Item $backendJar.FullName (Join-Path $BundleDir 'backend\Moddex-Backend.jar') -Force
+
+# --- frontend ----------------------------------------------------------------
+if (-not (Test-Path (Join-Path $FrontendDir 'package.json'))) { Die "Frontend project not found at $FrontendDir" }
+Write-Log 'Building frontend assets'
+Push-Location $FrontendDir
+try {
+    if (Test-Path (Join-Path $FrontendDir 'package-lock.json')) {
+        Invoke-Native { npm ci } 'Frontend dependency install'
+    } else {
+        Invoke-Native { npm install } 'Frontend dependency install'
+    }
+    Invoke-Native { npm run build -- --configuration production } 'Frontend build'
+} finally { Pop-Location }
+$frontendDist = Join-Path $FrontendDir 'dist'
+if (-not (Test-Path $frontendDist)) { Die "Frontend dist directory not found at $frontendDist" }
+Copy-Item -Path (Join-Path $frontendDist '*') -Destination (Join-Path $BundleDir 'frontend') -Recurse -Force
+
+# --- installer resources -----------------------------------------------------
+Write-Log 'Copying Windows installer resources'
+Copy-Item -Path (Join-Path $ProjectRoot 'scripts\windows') -Destination (Join-Path $BundleDir 'scripts\windows') -Recurse -Force
+Copy-Item -Path (Join-Path $ProjectRoot 'packaging\windows') -Destination (Join-Path $BundleDir 'packaging\windows') -Recurse -Force
+
+# Bundle a checksum-verified WinSW so the install is offline-capable. A local copy
+# can be supplied via MODDEX_WINSW_SOURCE (e.g. a CI cache); otherwise the pinned
+# release is downloaded with a few retries to ride out transient network errors.
+$winsw = Join-Path $BundleDir 'packaging\windows\WinSW.exe'
+if ($env:MODDEX_WINSW_SOURCE -and (Test-Path $env:MODDEX_WINSW_SOURCE)) {
+    Write-Log "Using local WinSW: $env:MODDEX_WINSW_SOURCE"
+    Copy-Item -Path $env:MODDEX_WINSW_SOURCE -Destination $winsw -Force
+} else {
+    Write-Log "Fetching WinSW $WinSwVersion"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    $ok = $false
+    for ($attempt = 1; $attempt -le 3 -and -not $ok; $attempt++) {
+        try {
+            Invoke-WebRequest -Uri $WinSwUrl -OutFile $winsw -UseBasicParsing -TimeoutSec 120
+            $ok = $true
+        } catch {
+            Write-Log "WinSW download attempt $attempt failed: $($_.Exception.Message)"
+            Start-Sleep -Seconds (2 * $attempt)
+        }
+    }
+    if (-not $ok) { Die "Failed to download WinSW from $WinSwUrl after 3 attempts" }
+}
+$actual = (Get-FileHash -Algorithm SHA256 -Path $winsw).Hash.ToLowerInvariant()
+if ($actual -ne $WinSwSha256) { Die "WinSW checksum mismatch (expected $WinSwSha256, got $actual)" }
+
+Set-Content -Path (Join-Path $BundleDir 'VERSION') -Value $Version -Encoding ASCII -NoNewline
+
+# --- archive -----------------------------------------------------------------
+$artifact = Join-Path $BuildDir "moddex-$Version-windows-x64.zip"
+Write-Log "Creating archive $artifact"
+Compress-Archive -Path (Join-Path $BundleDir '*') -DestinationPath $artifact -Force
+$hash = (Get-FileHash -Algorithm SHA256 -Path $artifact).Hash.ToLowerInvariant()
+"$hash *$(Split-Path -Leaf $artifact)" | Set-Content -Path "$artifact.sha256" -Encoding ASCII
+
+Write-Log "Bundle created at $artifact"

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -1,0 +1,211 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Installs (or upgrades) Moddex as a Windows service.
+
+.DESCRIPTION
+    The Windows counterpart of scripts/install.sh. It lays out a consistent path
+    layout, installs the backend JAR and the built frontend assets, registers the
+    backend as a Windows service via WinSW, and starts it.
+
+    Path layout:
+      App      : %ProgramFiles%\Moddex          (app.jar, frontend, service wrapper)
+      Data     : %ProgramData%\Moddex\data      (MODDEX_ROOT - instances, backups, settings)
+      Config   : %ProgramData%\Moddex\config
+      Logs     : %ProgramData%\Moddex\logs
+
+    The installer is idempotent: re-running it upgrades the application artifacts
+    without touching instance data, and preserves the machine-local mode/port from
+    the existing service definition unless -Mode/-Port is passed explicitly.
+
+.PARAMETER Mode
+    Deployment mode: local (loopback only), lan, or public.
+.PARAMETER Port
+    TCP port to expose the backend on (default: 8080).
+.PARAMETER BackendJar
+    Path to the backend JAR. Defaults to <bundle>\backend\Moddex-Backend.jar.
+.PARAMETER FrontendDir
+    Path to the built frontend assets. Defaults to <bundle>\frontend.
+.PARAMETER WinSwPath
+    Path to a WinSW executable to bundle. If omitted, a bundled copy
+    (packaging\windows\WinSW.exe) is used, else the pinned release is downloaded.
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('local', 'lan', 'public')]
+    [string]$Mode,
+    [int]$Port,
+    [string]$BackendJar,
+    [string]$FrontendDir,
+    [string]$WinSwPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# --- constants ---------------------------------------------------------------
+$ServiceId   = 'moddex-backend'
+$AppDir      = Join-Path $env:ProgramFiles 'Moddex'
+$DataRoot    = Join-Path $env:ProgramData 'Moddex'
+$DataDir     = Join-Path $DataRoot 'data'
+$ConfigDir   = Join-Path $DataRoot 'config'
+$LogDir      = Join-Path $DataRoot 'logs'
+$ServiceXml  = Join-Path $AppDir 'moddex-backend.xml'
+$ServiceExe  = Join-Path $AppDir 'moddex-backend.exe'
+$MinJava     = 17
+
+# Pinned WinSW (Windows Service Wrapper). The hash gates the downloaded binary so
+# a compromised mirror cannot inject a different executable (defense in depth,
+# matching the backend's SecureArtifactDownloader policy).
+$WinSwVersion = 'v2.12.0'
+$WinSwUrl     = "https://github.com/winsw/winsw/releases/download/$WinSwVersion/WinSW-x64.exe"
+$WinSwSha256  = '05b82d46ad331cc16bdc00de5c6332c1ef818df8ceefcd49c726553209b3a0da'
+
+$ScriptDir   = Split-Path -Parent $MyInvocation.MyCommand.Path
+$BundleRoot  = Split-Path -Parent (Split-Path -Parent $ScriptDir)   # <bundle>\scripts\windows -> <bundle>
+$PackagingWin = Join-Path $BundleRoot 'packaging\windows'
+
+function Write-Log([string]$Message) { Write-Host "[moddex-install] $Message" }
+function Die([string]$Message) { Write-Error $Message; exit 1 }
+
+# --- preflight ---------------------------------------------------------------
+function Assert-Admin {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+    if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        Die 'This installer must run from an elevated (Administrator) PowerShell session.'
+    }
+}
+
+function Resolve-JavaExe {
+    $candidates = @()
+    $cmd = Get-Command java.exe -ErrorAction SilentlyContinue
+    if ($cmd) { $candidates += $cmd.Source }
+    if ($env:JAVA_HOME) { $candidates += (Join-Path $env:JAVA_HOME 'bin\java.exe') }
+    foreach ($java in $candidates) {
+        if (-not (Test-Path $java)) { continue }
+        $verLine = (& $java -version 2>&1 | Select-Object -First 1)
+        if ($verLine -match '"(\d+)(\.(\d+))?') {
+            $major = [int]$Matches[1]
+            if ($major -eq 1 -and $Matches[3]) { $major = [int]$Matches[3] }  # 1.8 style
+            if ($major -ge $MinJava) { return $java }
+            Die "Found Java $major but Moddex requires Java $MinJava or newer."
+        }
+    }
+    Die "Java $MinJava+ not found. Install a JRE/JDK $MinJava or set JAVA_HOME."
+}
+
+# --- WinSW acquisition -------------------------------------------------------
+function Resolve-WinSw {
+    $bundled = if ($WinSwPath) { $WinSwPath } else { Join-Path $PackagingWin 'WinSW.exe' }
+    if (Test-Path $bundled) {
+        Write-Log "Using bundled WinSW: $bundled"
+        return $bundled
+    }
+    # Not bundled: download the pinned release and verify its hash.
+    $tmp = Join-Path $env:TEMP "WinSW-$WinSwVersion.exe"
+    Write-Log "Downloading WinSW $WinSwVersion …"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest -Uri $WinSwUrl -OutFile $tmp -UseBasicParsing
+    $actual = (Get-FileHash -Algorithm SHA256 -Path $tmp).Hash.ToLowerInvariant()
+    if ($actual -ne $WinSwSha256) {
+        Remove-Item $tmp -Force -ErrorAction SilentlyContinue
+        Die "WinSW checksum mismatch (expected $WinSwSha256, got $actual)."
+    }
+    return $tmp
+}
+
+# --- config resolution -------------------------------------------------------
+function Get-ExistingEnv([string]$Name) {
+    if (-not (Test-Path $ServiceXml)) { return $null }
+    [xml]$xml = Get-Content -Path $ServiceXml -Raw
+    $node = $xml.service.env | Where-Object { $_.name -eq $Name } | Select-Object -First 1
+    if ($node) { return $node.value } else { return $null }
+}
+
+function Resolve-Config {
+    $modeExplicit = $PSBoundParameters.ContainsKey('Mode')
+    $portExplicit = $PSBoundParameters.ContainsKey('Port')
+
+    $resolvedMode = $Mode
+    if (-not $modeExplicit) {
+        $existingMode = Get-ExistingEnv 'MODDEX_MODE'
+        if ($existingMode) { $resolvedMode = $existingMode }
+        elseif (-not $resolvedMode) {
+            Die 'No -Mode given and no existing install to inherit from. Pass -Mode local|lan|public.'
+        }
+    }
+
+    $resolvedPort = $Port
+    if (-not $portExplicit) {
+        $existingPort = Get-ExistingEnv 'SERVER_PORT'
+        if ($existingPort) { $resolvedPort = [int]$existingPort } else { $resolvedPort = 8080 }
+    }
+    if ($resolvedPort -lt 1 -or $resolvedPort -gt 65535) { Die "Invalid -Port: $resolvedPort" }
+
+    $address = if ($resolvedMode -eq 'local') { '127.0.0.1' } else { '0.0.0.0' }
+    return [pscustomobject]@{ Mode = $resolvedMode; Port = $resolvedPort; Address = $address }
+}
+
+# --- main --------------------------------------------------------------------
+Assert-Admin
+$javaExe = Resolve-JavaExe
+Write-Log "Using Java: $javaExe"
+
+if (-not $BackendJar)  { $BackendJar  = Join-Path $BundleRoot 'backend\Moddex-Backend.jar' }
+if (-not $FrontendDir) { $FrontendDir = Join-Path $BundleRoot 'frontend' }
+if (-not (Test-Path $BackendJar))  { Die "Backend JAR not found: $BackendJar" }
+if (-not (Test-Path $FrontendDir)) { Die "Frontend assets not found: $FrontendDir" }
+
+$cfg = Resolve-Config
+Write-Log "Mode=$($cfg.Mode) Address=$($cfg.Address) Port=$($cfg.Port)"
+
+foreach ($dir in @($AppDir, $DataDir, $ConfigDir, $LogDir)) {
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+}
+
+# Stop the service before replacing the JAR so the file is not locked.
+if (Get-Service -Name $ServiceId -ErrorAction SilentlyContinue) {
+    Write-Log 'Stopping existing service for upgrade …'
+    & $ServiceExe stop  2>$null | Out-Null
+}
+
+Write-Log 'Installing application artifacts …'
+Copy-Item -Path $BackendJar -Destination (Join-Path $AppDir 'app.jar') -Force
+$frontendTarget = Join-Path $AppDir 'frontend'
+if (Test-Path $frontendTarget) { Remove-Item -Recurse -Force $frontendTarget }
+Copy-Item -Path $FrontendDir -Destination $frontendTarget -Recurse -Force
+
+# Render the WinSW service definition from the template.
+$templatePath = Join-Path $PackagingWin 'moddex-backend.xml.template'
+if (-not (Test-Path $templatePath)) { Die "Service template not found: $templatePath" }
+$xml = Get-Content -Path $templatePath -Raw
+$xml = $xml.Replace('@@JAVA_EXE@@', $javaExe).
+            Replace('@@APP_DIR@@', $AppDir).
+            Replace('@@DATA_DIR@@', $DataDir).
+            Replace('@@CONFIG_DIR@@', $ConfigDir).
+            Replace('@@LOG_DIR@@', $LogDir).
+            Replace('@@MODE@@', $cfg.Mode).
+            Replace('@@SERVER_ADDRESS@@', $cfg.Address).
+            Replace('@@SERVER_PORT@@', [string]$cfg.Port)
+Set-Content -Path $ServiceXml -Value $xml -Encoding UTF8
+
+# Place the WinSW executable next to its XML (WinSW derives the config from its
+# own file name: moddex-backend.exe -> moddex-backend.xml).
+Copy-Item -Path (Resolve-WinSw) -Destination $ServiceExe -Force
+
+# (Re)install and start the service.
+if (Get-Service -Name $ServiceId -ErrorAction SilentlyContinue) {
+    Write-Log 'Updating service registration …'
+    & $ServiceExe uninstall | Out-Null
+    Start-Sleep -Seconds 1
+}
+Write-Log 'Registering Windows service …'
+& $ServiceExe install | Out-Null
+& $ServiceExe start   | Out-Null
+
+Write-Log "Moddex installed. Service '$ServiceId' is running on $($cfg.Address):$($cfg.Port)."
+Write-Log "Data: $DataDir   Config: $ConfigDir   Logs: $LogDir"
+if ($cfg.Mode -ne 'local') {
+    Write-Log 'Reminder: open the firewall for the chosen port and complete first-run setup in the web UI.'
+}

--- a/scripts/windows/smoke-test.ps1
+++ b/scripts/windows/smoke-test.ps1
@@ -1,0 +1,79 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    End-to-end install smoke test for the Moddex Windows service.
+
+.DESCRIPTION
+    The Windows counterpart of scripts/smoke-test.sh. It installs Moddex as a
+    service (local mode), verifies the backend comes up, that a protected endpoint
+    rejects anonymous access (auth is enforced), reports the resolved paths, and
+    then uninstalls and purges. Intended for a throwaway Windows CI runner or VM.
+
+.PARAMETER Port
+    Port to install on (default: 8080).
+.PARAMETER KeepInstalled
+    Skip the uninstall step (leave the service running for manual inspection).
+#>
+[CmdletBinding()]
+param(
+    [int]$Port = 8080,
+    [switch]$KeepInstalled
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$BaseUrl   = "http://127.0.0.1:$Port"
+$failures  = 0
+
+function Ok([string]$m)   { Write-Host "[ OK ] $m" -ForegroundColor Green }
+function Bad([string]$m)  { Write-Host "[FAIL] $m" -ForegroundColor Red; $script:failures++ }
+function Info([string]$m) { Write-Host "[ -- ] $m" }
+
+function Get-Status([string]$Path) {
+    try {
+        $r = Invoke-WebRequest -Uri "$BaseUrl$Path" -Method GET -UseBasicParsing -TimeoutSec 5
+        return [int]$r.StatusCode
+    } catch [System.Net.WebException] {
+        if ($_.Exception.Response) { return [int]$_.Exception.Response.StatusCode }
+        return 0
+    } catch { return 0 }
+}
+
+Info "Installing Moddex (local mode, port $Port) …"
+& (Join-Path $ScriptDir 'install.ps1') -Mode local -Port $Port
+
+# Wait for the backend to answer (Spring Boot start can take a while).
+Info 'Waiting for the backend to become reachable …'
+$reachable = $false
+for ($i = 0; $i -lt 60; $i++) {
+    $code = Get-Status '/api/v1/setup/status'
+    if ($code -ne 0) { $reachable = $true; break }
+    Start-Sleep -Seconds 2
+}
+if ($reachable) { Ok "backend reachable (/api/v1/setup/status -> $(Get-Status '/api/v1/setup/status'))" }
+else { Bad 'backend not reachable after ~120s' }
+
+# A clean exit code 0 of the service means the SCM considers it running.
+$svc = Get-Service -Name 'moddex-backend' -ErrorAction SilentlyContinue
+if ($svc -and $svc.Status -eq 'Running') { Ok "service status: $($svc.Status)" }
+else { Bad "service not running: $(if ($svc) { $svc.Status } else { 'absent' })" }
+
+# Protected endpoint must reject anonymous access.
+$anon = Get-Status '/api/v1/instance'
+if ($anon -eq 401 -or $anon -eq 403) { Ok "auth enforced (/instance -> $anon without a token)" }
+elseif ($anon -eq 200) { Bad '/instance served WITHOUT a token (200) — auth not enforced' }
+else { Info "unexpected anonymous status for /instance: $anon (continuing)" }
+
+Info "Data:   $(Join-Path $env:ProgramData 'Moddex\data')"
+Info "Config: $(Join-Path $env:ProgramData 'Moddex\config')"
+Info "Logs:   $(Join-Path $env:ProgramData 'Moddex\logs')"
+
+if (-not $KeepInstalled) {
+    Info 'Uninstalling (purge) …'
+    & (Join-Path $ScriptDir 'uninstall.ps1') -Purge
+}
+
+if ($failures -gt 0) { Write-Error "Smoke test failed with $failures failure(s)."; exit 1 }
+Ok 'Smoke test passed.'

--- a/scripts/windows/uninstall.ps1
+++ b/scripts/windows/uninstall.ps1
@@ -1,0 +1,65 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Removes the Moddex Windows service and application files.
+
+.DESCRIPTION
+    The Windows counterpart of scripts/uninstall.sh. By default it stops and
+    removes the service and the application directory under %ProgramFiles%\Moddex
+    but PRESERVES instance data and config under %ProgramData%\Moddex, mirroring
+    the Linux installer's non-destructive default. Pass -Purge to also remove all
+    data, config and logs.
+
+.PARAMETER Purge
+    Also delete %ProgramData%\Moddex (instances, backups, settings, logs).
+#>
+[CmdletBinding()]
+param(
+    [switch]$Purge
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ServiceId  = 'moddex-backend'
+$AppDir     = Join-Path $env:ProgramFiles 'Moddex'
+$DataRoot   = Join-Path $env:ProgramData 'Moddex'
+$ServiceExe = Join-Path $AppDir 'moddex-backend.exe'
+
+function Write-Log([string]$Message) { Write-Host "[moddex-uninstall] $Message" }
+function Die([string]$Message) { Write-Error $Message; exit 1 }
+
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = New-Object Security.Principal.WindowsPrincipal($identity)
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Die 'This uninstaller must run from an elevated (Administrator) PowerShell session.'
+}
+
+if (Get-Service -Name $ServiceId -ErrorAction SilentlyContinue) {
+    Write-Log 'Stopping and removing the service …'
+    if (Test-Path $ServiceExe) {
+        & $ServiceExe stop      2>$null | Out-Null
+        & $ServiceExe uninstall 2>$null | Out-Null
+    } else {
+        # Fall back to SCM if the wrapper exe is already gone.
+        Stop-Service -Name $ServiceId -Force -ErrorAction SilentlyContinue
+        sc.exe delete $ServiceId | Out-Null
+    }
+    Start-Sleep -Seconds 1
+}
+
+if (Test-Path $AppDir) {
+    Write-Log "Removing application directory $AppDir"
+    Remove-Item -Recurse -Force $AppDir
+}
+
+if ($Purge) {
+    if (Test-Path $DataRoot) {
+        Write-Log "Purging data directory $DataRoot"
+        Remove-Item -Recurse -Force $DataRoot
+    }
+} else {
+    Write-Log "Instance data preserved at $DataRoot (pass -Purge to remove it)."
+}
+
+Write-Log 'Moddex uninstalled.'


### PR DESCRIPTION
Teil von / erfüllt aklozyp/Moddex#26 ([Story][v0.3] Windows Installer und Plattformintegration)

## Was
Native Windows-Unterstützung parallel zum Linux-Installer.

## Tasks (#26) abgedeckt
- **Installer-Technologie**: PowerShell (`install.ps1`, elevated, idempotent).
- **Service-Strategie**: Windows-Dienst via **WinSW** (checksum-gepinnt), gleicher
  `MODDEX_ROOT/CONFIG_DIR/LOG_DIR` + `SERVER_ADDRESS/PORT`-Env-Vertrag wie die systemd-Unit;
  Auto-Restart bei Crash, größenrotierte Logs.
- **Pfadkonzept**: App unter `%ProgramFiles%\Moddex`; Daten/Config/Logs unter
  `%ProgramData%\Moddex\{data,config,logs}`. Re-Install behält Daten und mode/port
  (außer `-Mode`/`-Port` explizit).
- **CI-Build**: nicht-gating `build-windows`-Job (windows-2022) in `ci.yml`; `release.yml`
  hängt das `moddex-<tag>-windows-x64.zip` (+SHA256) an das GitHub-Release.
- **Smoke-Test**: `smoke-test.ps1` (Install → Erreichbarkeit + Auth-Erzwingung → Uninstall).
- **README**: Supported-Platforms-Zeile + Windows-Installations-/Service-/Pfad-Abschnitt.

## Sicherheit
WinSW wird über eine gepinnte HTTPS-URL **mit SHA256-Verifikation** bezogen (Defense-in-Depth,
analog zum `SecureArtifactDownloader` des Backends); ein Mismatch bricht ab.
`build-bundle.ps1` bündelt das verifizierte WinSW → Offline-Installation möglich.

## Verifikation (lokal)
Das Windows-Bundle baut **end-to-end** (Backend-JAR + Frontend-Prod-Build + WinSW + Skripte)
und erzeugt das ZIP + Checksum. Alle vier PowerShell-Skripte bestehen den PowerShell-Parser.
Robustheitsfixe: Native-Command-stderr (npm-Warnungen) brechen den Build nicht mehr ab;
WinSW-Download mit Retries + lokalem Quell-Override für CI-Caches.

## Nicht enthalten
Echtes Dienst-Register-Smoke auf einem Windows-Runner ist dem CI/QA vorbehalten
(erfordert Admin); die Logik ist über `smoke-test.ps1` bereitgestellt.
