### PR TITLE
ci+docs: Release-Notes-Prozess finalisieren (#42)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,43 @@
+# Configuration for GitHub's automatically generated release notes.
+# Used by the `generate_release_notes: true` step in .github/workflows/release.yml:
+# merged pull requests are grouped into the categories below based on their labels.
+# See: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - duplicate
+      - invalid
+      - wontfix
+    authors:
+      - dependabot
+      - github-actions
+  categories:
+    - title: 🚀 Features
+      labels:
+        - enhancement
+        - feature
+        - story
+        - epic
+    - title: 🐞 Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: 🔒 Security
+      labels:
+        - security
+    - title: 📖 Documentation
+      labels:
+        - docs
+        - documentation
+    - title: 🌐 Internationalization
+      labels:
+        - i18n
+    - title: 🔧 Build, CI & Packaging
+      labels:
+        - ci
+        - build
+        - packaging
+    - title: 🧹 Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,10 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.TARGET_REF }}
+          # Auto-generate the notes body from merged PRs, grouped per
+          # .github/release.yml. The Windows job below only appends assets and
+          # leaves this body untouched.
+          generate_release_notes: true
           files: |
             moddex-${{ env.TARGET_REF }}-linux-amd64.tar.gz
             moddex-${{ env.TARGET_REF }}-linux-amd64.tar.gz.sha256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to Moddex are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims to
+follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This file is the human-curated, high-level history. The per-release GitHub
+Release page additionally carries auto-generated notes listing every merged pull
+request (see [`docs/releasing.md`](docs/releasing.md)).
+
+## [Unreleased]
+
+The following work is merged on `develop` but not yet tagged in a release.
+
+### Added
+
+- **CurseForge integration** (epic #17 / #25): read-only CurseForge mod provider
+  behind the existing marketplace abstraction (search, details, versions,
+  filters) and CurseForge modpack import with format auto-detection and hardened,
+  transactional file resolution. Frontend gains secret-safe API-key handling and
+  provider-specific error messages.
+- **Full 7-language UI** (#27): German, English, Spanish, French, Chinese,
+  Japanese and Arabic, with right-to-left layout for Arabic and an enforced
+  translation-parity test.
+- **Windows support** (#26): PowerShell installer that registers the backend as a
+  Windows service via WinSW, a `%ProgramData%\Moddex` path layout, a build/release
+  pipeline producing a checksum-verified `windows-x64.zip`, plus uninstall and
+  smoke-test scripts.
+- **Operator documentation** (#40): troubleshooting / known-issues guide and an
+  upgrade & rollback guide for both Linux and Windows; GitHub issue/PR templates
+  and `SUPPORT.md` so problems can be reported in a structured way.
+- **Release process** (#42): automatically generated GitHub Release notes
+  (`.github/release.yml`), this changelog and [`docs/releasing.md`](docs/releasing.md).
+
+### Changed
+
+- Windows installer now records the installed version in
+  `%ProgramFiles%\Moddex\VERSION` for parity with Linux.
+
+> _v0.2 "Public Beta Foundation" (secure local/lan/public modes with fail-closed
+> CORS and enforced authentication, the native Linux installer + systemd service +
+> `moddex` CLI, backup/restore data-safety guarantees, Modrinth mod management and
+> the QA/recovery checklists) is also part of this unreleased range._
+
+## [0.1.1] - 2025-09-24
+
+### Changed
+
+- Maintenance and installer fixes on top of the initial release.
+
+## [0.1.0] - 2025-09-22
+
+### Added
+
+- Initial Moddex release: native Linux deployment of the backend and web UI.
+
+[Unreleased]: https://github.com/aklozyp/Moddex/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/aklozyp/Moddex/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/aklozyp/Moddex/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -421,6 +421,14 @@ The same bundle is built in CI and on tags by GitHub Actions. See
 [`docs/ci.md`](docs/ci.md) for the build matrix, the required cross-repo
 checkout secret, the release process and the Arch/Windows status.
 
+## Releases & changelog
+
+Notable changes are recorded in the **[CHANGELOG](CHANGELOG.md)**; each GitHub
+Release additionally carries auto-generated notes listing every merged pull
+request. Maintainers cutting a release should follow the
+**[release process](docs/releasing.md)** and the
+[release checklist](docs/qa/release-checklist.md).
+
 ## Quality assurance
 
 Before each release, run the recovery QA pass to make sure restore, mod changes

--- a/docs/qa/release-checklist.md
+++ b/docs/qa/release-checklist.md
@@ -1,5 +1,8 @@
 # Release smoke test & checklist (v0.2)
 
+> This is the pre-tag smoke gate. For the end-to-end release procedure (tagging,
+> changelog, generated notes), see [`docs/releasing.md`](../releasing.md).
+
 Before publishing a v0.2 release, the critical end-to-end flow must pass so that
 installer or core-flow regressions are caught **before** users hit them.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,68 @@
+# Releasing Moddex
+
+How a maintainer cuts a Moddex release. The goal is that every published release
+has reproducible artifacts **and** clear notes, so users see what changed and
+which limitations still apply.
+
+## Versioning
+
+Moddex follows [Semantic Versioning](https://semver.org/): `vMAJOR.MINOR.PATCH`.
+Tags are prefixed with `v` (e.g. `v0.4.0`). The same tag is applied to **all
+three** repositories — `Moddex` (this one), `Moddex-Backend` and
+`Moddex-Frontend` — because the release pipeline checks them out at that ref.
+
+## What produces the release notes
+
+Two layers, by design:
+
+1. **Auto-generated, exhaustive.** `release.yml` passes
+   `generate_release_notes: true` to the GitHub Release step, so GitHub lists
+   every merged pull request since the previous tag. Pull requests are grouped
+   into categories (Features, Bug Fixes, Security, Documentation, …) according to
+   their labels — configured in [`.github/release.yml`](../.github/release.yml).
+   Label your PRs accordingly so they land in the right section.
+2. **Human-curated, high-level.** [`CHANGELOG.md`](../CHANGELOG.md) summarizes the
+   noteworthy changes per version in Keep a Changelog format. Keep an
+   `[Unreleased]` section at the top and add entries as features land, rather than
+   reconstructing them at release time.
+
+## Cutting a release
+
+1. **Pass the release gate.** Work through
+   [`docs/qa/release-checklist.md`](qa/release-checklist.md): CI green on the
+   source branches, fresh-host install + `release-smoke-test.sh`, the
+   `recovery-checklist.md` blocker rows, and update-resistance (a second installer
+   run preserves config + data). A release is **blocked** if any checked smoke
+   step fails or any 🚫 recovery row regresses.
+2. **Finalize the changelog.** In `CHANGELOG.md`, rename the `[Unreleased]`
+   section to the new version with today's date, add a fresh empty `[Unreleased]`
+   above it, and update the compare links at the bottom.
+3. **Note known limitations.** Make sure the changelog / release call out
+   experimental features and platform status (the auto-notes do not). See the
+   "known limitations" rows in `recovery-checklist.md`.
+4. **Tag all three repos** with the same tag and push:
+   ```bash
+   TAG=v0.4.0
+   for repo in Moddex Moddex-Backend Moddex-Frontend; do
+     git -C "../$repo" tag -a "$TAG" -m "Moddex $TAG" && git -C "../$repo" push origin "$TAG"
+   done
+   ```
+   Pushing the tag to `Moddex` triggers [`release.yml`](../.github/workflows/release.yml),
+   which builds the Linux bundle and (in a dependent job) the Windows bundle, then
+   publishes the GitHub Release with checksums and the generated notes.
+   Alternatively, run the `release` workflow via **workflow_dispatch** and pass the
+   tag explicitly.
+5. **Verify the published release.** Confirm both the Linux tarball and the
+   Windows zip (plus their `.sha256` files) are attached and that the notes
+   rendered. Spot-check a checksum.
+
+## Prerequisites
+
+- A repository/organization secret `MODDEX_CHECKOUT_TOKEN` with read access to all
+  three repos (the backend/frontend repos are private). See [`docs/ci.md`](ci.md).
+
+## Related
+
+- [Release checklist](qa/release-checklist.md) — the pre-tag smoke gate.
+- [CHANGELOG](../CHANGELOG.md).
+- [Upgrade & rollback guide](upgrade.md) — what users do with a new release.


### PR DESCRIPTION
Closes #42
Refs #28, #18

## Worum geht es?
v0.4-Task „Release-Notes-Prozess finalisieren" (#28). Bisher wurden Releases ohne Notes-Body veröffentlicht und es gab kein CHANGELOG — Nutzer konnten Änderungen und bekannte Einschränkungen nicht nachvollziehen.

## Änderungen
- **`release.yml`** — `generate_release_notes: true` am Linux-Release-Schritt: GitHub erzeugt die Notes aus allen seit dem letzten Tag gemergten PRs. Der Windows-Job hängt nur Assets an und lässt den Body unangetastet.
- **`.github/release.yml`** — gruppiert die automatischen Notes nach PR-Label in Kategorien (Features, Bug Fixes, Security, Documentation, i18n, Build/CI/Packaging, Other); Bots und `ignore-for-release` ausgeschlossen.
- **`CHANGELOG.md`** — Keep-a-Changelog-Historie mit `Unreleased`-Abschnitt, der die gemergte, aber **noch nicht veröffentlichte** v0.2/v0.3-Arbeit (CurseForge, i18n, Windows, Operator-Doku) auf hoher Ebene erfasst, plus released v0.1.x.
- **`docs/releasing.md`** — End-to-End-Release-Prozess (Smoke-Gate → Changelog finalisieren → alle drei Repos taggen → verifizieren). Verlinkt aus README und Release-Checklist (mit Rück-Link).

## Kontext
v0.1.0/v0.1.1 sind released; v0.2 und v0.3 sind gemergt, aber noch nicht getaggt — daher der große `Unreleased`-Block.

## Wie getestet?
- `.github/release.yml` und `release.yml` gegen `yaml.safe_load` validiert (beide OK).
- Reine CI-Config-/Doku-Änderung; kein Anwendungscode betroffen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)