### PR TITLE
fix(windows): operator-eigene <env> beim Upgrade erhalten (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ The following work is merged on `develop` but not yet tagged in a release.
 - Windows installer now records the installed version in
   `%ProgramFiles%\Moddex\VERSION` for parity with Linux.
 
+### Fixed
+
+- Windows installer no longer drops operator-added `<env>` entries (e.g.
+  `MODDEX_CORS_ALLOWED_ORIGINS`) when re-rendering the service definition on an
+  upgrade; they are carried over, matching `install.sh`'s behaviour (#44).
+
 > _v0.2 "Public Beta Foundation" (secure local/lan/public modes with fail-closed
 > CORS and enforced authentication, the native Linux installer + systemd service +
 > `moddex` CLI, backup/restore data-safety guarantees, Modrinth mod management and

--- a/docs/qa/release-checklist.md
+++ b/docs/qa/release-checklist.md
@@ -91,8 +91,28 @@ Tick every item before tagging a release:
       restore / mod rollback / broken modpack / full disk.
 - [ ] Re-running the installer preserves `/etc/moddex/moddex.env` and instance
       data (update-resistance).
+- [ ] **Migration paths verified** (see below): a plain upgrade keeps the
+      operator's mode/port, instance data and any operator-added config, and
+      records the new version.
 - [ ] Release notes list known limitations (experimental features, Arch/Windows
       status).
+
+### Migration verification matrix
+
+Run an upgrade (install version A, then re-run the installer for version B over
+it) and confirm each path. These are the migrations the installers implement; a
+silent regression here corrupts an existing deployment.
+
+| # | Path | Linux | Windows | Expected |
+|---|------|-------|---------|----------|
+| M1 | Mode/port preserved on plain upgrade | `install.sh` (no `--mode/--port`) | `install.ps1` (no `-Mode/-Port`) | previous mode + port unchanged |
+| M2 | Operator-added config preserved | extra keys in `moddex.env` (e.g. `MODDEX_CORS_ALLOWED_ORIGINS`) | extra `<env>` in `moddex-backend.xml` | still present after upgrade |
+| M3 | Explicit override applies, rest preserved | `--mode lan` only changes mode keys | `-Mode lan` only changes mode keys | changed key updated, others kept |
+| M4 | Instance data untouched | `/var/lib/moddex` | `%ProgramData%\Moddex\data` | unchanged |
+| M5 | Version recorded | `/opt/moddex/VERSION` | `%ProgramFiles%\Moddex\VERSION` | shows the new version |
+| M6 | Legacy systemd unit migrated (Linux only) | pre-`moddex.env` install | — | mode/port recovered from the old unit |
+
+A release is **blocked** if M1–M5 regress on either platform.
 
 A release is **blocked** if any checked smoke step fails or any 🚫 recovery row
 regresses.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -126,9 +126,8 @@ Security-Mode zum Betriebsmodus passt.
 - Stelle sicher, dass `MODDEX_SECURITY_MODE` **gleich** `MODDEX_MODE` ist.
   - Linux: in `/etc/moddex/moddex.env`.
   - Windows: in `%ProgramFiles%\Moddex\moddex-backend.xml` (`<env>`-Einträge).
-    Beachte: Auf Windows werden manuell ergänzte `<env>`-Einträge (z. B.
-    `MODDEX_CORS_ALLOWED_ORIGINS`) bei einem Upgrade **nicht** automatisch
-    übernommen — siehe [Upgrade-Hinweis](upgrade.md#upgrade--windows).
+    Manuell ergänzte `<env>`-Einträge (z. B. `MODDEX_CORS_ALLOWED_ORIGINS`)
+    bleiben bei einem Upgrade erhalten — siehe [Upgrade-Hinweis](upgrade.md#upgrade--windows).
 - Bevorzugt: Web-UI und API über **dieselbe** Origin hinter einem Reverse Proxy
   ausliefern (nginx-Beispiel im [README](../README.md)) — dann entfällt CORS.
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -93,12 +93,12 @@ Expand-Archive moddex.zip -DestinationPath moddex-$Tag -Force
 
 Ohne `-Mode`/`-Port` übernimmt der Installer **Modus und Port** aus dem
 bestehenden `moddex-backend.xml`; nur `app.jar`/Frontend, die `VERSION` und die
-checksum-gepinnte WinSW-Binary werden ersetzt.
+checksum-gepinnte WinSW-Binary werden ersetzt. Manuell ergänzte `<env>`-Einträge
+(z. B. `MODDEX_CORS_ALLOWED_ORIGINS`) bleiben beim Upgrade **erhalten** — der
+Installer übernimmt sie aus der vorhandenen Service-XML (Parität zu Linux).
 
-> ⚠️ **Andere** manuell ergänzte `<env>`-Einträge (z. B.
-> `MODDEX_CORS_ALLOWED_ORIGINS`) werden beim Upgrade **nicht** übernommen, weil
-> die Service-XML neu aus der Vorlage erzeugt wird. Sichere `moddex-backend.xml`
-> vor dem Upgrade (Schritt 0) und trage solche Einträge danach erneut ein.
+> 💡 Trotzdem empfohlen: `moddex-backend.xml` im Backup von Schritt 0 sichern,
+> damit du im Rollback-Fall den exakten vorherigen Stand wiederherstellen kannst.
 
 ---
 

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -116,11 +116,34 @@ function Resolve-WinSw {
 }
 
 # --- config resolution -------------------------------------------------------
+# Env names the template renders from -Mode/-Port; everything else in an existing
+# service definition was added by the operator and must survive an upgrade.
+$ManagedEnv = @(
+    'MODDEX_ROOT', 'MODDEX_CONFIG_DIR', 'MODDEX_LOG_DIR',
+    'MODDEX_MODE', 'MODDEX_SECURITY_MODE', 'SERVER_ADDRESS', 'SERVER_PORT'
+)
+
 function Get-ExistingEnv([string]$Name) {
     if (-not (Test-Path $ServiceXml)) { return $null }
     [xml]$xml = Get-Content -Path $ServiceXml -Raw
     $node = $xml.service.env | Where-Object { $_.name -eq $Name } | Select-Object -First 1
     if ($node) { return $node.value } else { return $null }
+}
+
+# Operator-added <env> entries (anything not in $ManagedEnv) from the existing
+# service definition, so a re-install/upgrade preserves them instead of dropping
+# them when the XML is re-rendered (parity with install.sh's upsert_env_key,
+# e.g. MODDEX_CORS_ALLOWED_ORIGINS).
+function Get-UnmanagedEnv {
+    if (-not (Test-Path $ServiceXml)) { return @() }
+    [xml]$existing = Get-Content -Path $ServiceXml -Raw
+    $kept = @()
+    foreach ($node in @($existing.service.env)) {
+        if ($node -and $node.name -and ($ManagedEnv -notcontains $node.name)) {
+            $kept += [pscustomobject]@{ Name = [string]$node.name; Value = [string]$node.value }
+        }
+    }
+    return $kept
 }
 
 function Resolve-Config {
@@ -200,7 +223,24 @@ $xml = $xml.Replace('@@JAVA_EXE@@', $javaExe).
             Replace('@@MODE@@', $cfg.Mode).
             Replace('@@SERVER_ADDRESS@@', $cfg.Address).
             Replace('@@SERVER_PORT@@', [string]$cfg.Port)
-Set-Content -Path $ServiceXml -Value $xml -Encoding UTF8
+
+# Re-render replaces the whole file, so carry over any operator-added <env>
+# entries from the previous definition before writing (read while the old XML is
+# still on disk). Managed keys keep coming from the template above.
+$preservedEnv = Get-UnmanagedEnv
+if ($preservedEnv.Count -gt 0) {
+    [xml]$doc = $xml
+    foreach ($extra in $preservedEnv) {
+        $node = $doc.CreateElement('env')
+        $node.SetAttribute('name', $extra.Name)
+        $node.SetAttribute('value', $extra.Value)
+        $doc.DocumentElement.AppendChild($node) | Out-Null
+        Write-Log "Preserving operator-added env entry: $($extra.Name)"
+    }
+    $doc.Save($ServiceXml)
+} else {
+    Set-Content -Path $ServiceXml -Value $xml -Encoding UTF8
+}
 
 # Place the WinSW executable next to its XML (WinSW derives the config from its
 # own file name: moddex-backend.exe -> moddex-backend.xml).


### PR DESCRIPTION
Closes #44
Refs #28, #18

## Worum geht es?
v0.4-Task „Installer-Migrationen prüfen". Beim Audit beider Installer fand sich ein realer Windows-Defekt: `install.ps1` rendert `moddex-backend.xml` bei jedem Lauf komplett neu und übernahm nur `MODDEX_MODE`/`SERVER_PORT`. Operator-eigene `<env>`-Einträge (insb. `MODDEX_CORS_ALLOWED_ORIGINS`) gingen bei **jedem Upgrade verloren**. Linux (`install.sh`) erhält solche Keys bereits via `upsert_env_key`.

## Fix
- **`install.ps1`** — `Get-UnmanagedEnv` liest vor dem Überschreiben die nicht verwalteten `<env>`-Einträge der bestehenden Definition aus und fügt sie nach dem Rendern wieder ein. Verwaltete Keys (`MODDEX_ROOT/CONFIG_DIR/LOG_DIR/MODE/SECURITY_MODE`, `SERVER_ADDRESS/PORT`) kommen weiterhin aus Modus/Port.
- **`docs/upgrade.md` + `docs/troubleshooting.md`** — custom `<env>` bleibt jetzt erhalten (Parität zu Linux); „geht verloren"-Warnung entfernt.
- **`docs/qa/release-checklist.md`** — Migrations-Verifikationsmatrix (M1–M6) + release-blockierendes Gate, damit der Upgrade-Pfad vor dem Taggen geprüft wird.
- **`CHANGELOG.md`** — Fix unter `Unreleased`.

## Audit-Ergebnis (Task „prüfen")
- Linux: Mode/Port-Erhalt, `upsert_env_key`, Legacy-systemd-Migration, Log-Dir-Migration, VERSION-Fallback — **korrekt**.
- Windows: Mode/Port + VERSION ok; custom-env-Verlust — **behoben** (dieser PR).

## Wie getestet?
- `install.ps1` Parser-Check (OK).
- Isolierter Funktionstest der Merge-Logik: alte XML mit `MODDEX_CORS_ALLOWED_ORIGINS` + `JAVA_OPTS` → Re-Render auf `mode=lan/port=8080` → **Assertions bestanden**: verwaltete Keys neu, custom-Keys erhalten, kein Duplikat, valide WinSW-XML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)