### PR TITLE
security: pre-release security review + meta hardening (#46)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Dependabot keeps the CI/release GitHub Actions in this repository up to date so
+# a known-vulnerable action version does not linger. The backend (Maven) and
+# frontend (npm) dependencies are tracked by equivalent configs in their own
+# repositories.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - ci
+      - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ concurrency:
   group: moddex-ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: this workflow only checks out code and builds. It never writes
+# to the repo, so the default GITHUB_TOKEN is dropped to read-only. (The private
+# cross-repo checkouts use MODDEX_CHECKOUT_TOKEN, not this token.)
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -26,6 +26,10 @@ concurrency:
   group: moddex-smoke-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: builds and boots a throwaway backend; never writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   smoke:
     runs-on: ubuntu-22.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ The following work is merged on `develop` but not yet tagged in a release.
 - Windows installer now records the installed version in
   `%ProgramFiles%\Moddex\VERSION` for parity with Linux.
 
+### Security
+
+- Pre-release security review across all three repositories
+  ([docs/qa/security-review.md](docs/qa/security-review.md), #46); added
+  `SECURITY.md`, least-privilege `permissions` on the CI/smoke workflows and a
+  Dependabot config for GitHub Actions.
+
 ### Fixed
 
 - Windows installer no longer drops operator-added `<env>` entries (e.g.

--- a/README.md
+++ b/README.md
@@ -434,6 +434,10 @@ request. Maintainers cutting a release should follow the
 Before each release, run the recovery QA pass to make sure restore, mod changes
 and file operations cannot silently destroy instances:
 
+- **Security review:** [`docs/qa/security-review.md`](docs/qa/security-review.md)
+  — the pre-release review across backend, frontend and CI (auth, CORS,
+  file/download, secret handling, XSS, workflow permissions). See also
+  [`SECURITY.md`](SECURITY.md) for vulnerability reporting.
 - **Manual matrix:** [`docs/qa/recovery-checklist.md`](docs/qa/recovery-checklist.md)
   — versioned checklist covering backup → restore → start, mod-install rollback,
   broken modpacks, full-disk/aborted-download scenarios and a fresh-install smoke

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions or pull requests.**
+
+Instead, use GitHub's private vulnerability reporting: open the **Security** tab
+of the [Moddex repository](https://github.com/aklozyp/Moddex) and choose
+**“Report a vulnerability”**. This keeps the report confidential until a fix is
+available.
+
+Please include, as far as you can:
+
+- the affected component (backend, frontend, installer/packaging) and version
+  (`moddex version` on Linux, or the release tag);
+- the operating mode (`local` / `lan` / `public`) and platform;
+- a description of the issue and its impact;
+- steps to reproduce or a proof of concept;
+- any relevant logs — **with secrets, tokens and passwords removed**.
+
+## Scope
+
+Moddex consists of three repositories that are released together:
+
+- `aklozyp/Moddex` — installer, packaging, CI and documentation;
+- `aklozyp/Moddex-Backend` — the API/service (Kotlin/Spring Boot);
+- `aklozyp/Moddex-Frontend` — the web UI (Angular).
+
+A vulnerability in any of them is in scope; report it through the public
+`Moddex` repository as described above.
+
+## Supported versions
+
+Moddex is pre-1.0 and ships from the latest release. Security fixes target the
+most recent release; there is no long-term support branch yet.
+
+## Hardening guidance
+
+Operators should review the secure-operation guidance before exposing Moddex
+beyond `localhost`:
+
+- [README — Private Linux Operation](README.md#private-linux-operation)
+  (operating modes, authentication, firewall, reverse proxy with TLS);
+- [Troubleshooting — CORS / security mode](docs/troubleshooting.md);
+- the security review of the current release in
+  [docs/qa/security-review.md](docs/qa/security-review.md).
+
+## Our commitments
+
+- We aim to acknowledge a report within a few days.
+- We will keep the report confidential and coordinate a fix and disclosure.
+- We credit reporters who wish to be named once a fix ships.

--- a/docs/qa/security-review.md
+++ b/docs/qa/security-review.md
@@ -1,0 +1,173 @@
+# Moddex Security Review (v0.4)
+
+> Pre-release security review across all three repositories — `Moddex`
+> (installer/packaging/CI), `Moddex-Backend` (Kotlin/Spring Boot) and
+> `Moddex-Frontend` (Angular). Tracked in
+> [#46](https://github.com/aklozyp/Moddex/issues/46).
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-06-27 |
+| Scope | Backend, Frontend, Build/Packaging/CI |
+| Method | Manual code review of the authentication, CORS, file/download, secret-handling, XSS and CI surfaces |
+
+## Severity scale
+
+**High** — exploitable remotely with meaningful impact · **Medium** — exploitable
+under a realistic configuration or defense-in-depth gap · **Low** — hardening /
+limited impact · **Info** — accepted trade-off, documented.
+
+## Summary
+
+No High-severity issues were found. The backend is well-hardened: strong path
+sanitisation and a trust policy for modpack imports, an SSRF-resistant artifact
+downloader, bcrypt credentials with login rate-limiting, fail-closed CORS and
+public-safe error responses. The findings below are two Medium defense-in-depth
+gaps and several Low/Info hardening items.
+
+| ID | Severity | Area | Finding | Status |
+|----|----------|------|---------|--------|
+| B1 | Medium | Backend | `serversettings.json` (JWT secret, admin hash, API key) written with default file permissions | **Fixed** — backend PR |
+| B2 | Medium | Backend | `X-Forwarded-For` trusted unconditionally → IP spoofing when directly exposed in `public` mode | Tracked — [#47](https://github.com/aklozyp/Moddex/issues/47) |
+| F1 | Low | Frontend | Unused `SafeHtmlPipe` (`bypassSecurityTrustHtml`) — latent XSS footgun | **Fixed** — frontend PR |
+| F2 | Low | Frontend | No Content-Security-Policy | **Fixed** — frontend PR |
+| C1 | Medium | CI | `ci.yml`/`smoke.yml` had no least-privilege `permissions` | **Fixed** — this PR |
+| C2 | Low | CI | Actions pinned by mutable tag, not commit SHA | Recommendation (below) |
+| C3 | Low | Repo | No `SECURITY.md` disclosure policy | **Fixed** — this PR |
+| C4 | Low | Repo | No Dependabot / dependency scanning | **Fixed** (meta) — this PR |
+| B3 | Info | Backend | Console WebSocket auth via token query param | Accepted (documented) |
+| F3 | Info | Frontend | JWT stored in `localStorage` | Accepted (documented) |
+
+---
+
+## Backend
+
+### B1 — Secrets file written without restrictive permissions (Medium)
+
+`ServerSettingsService` persists `serversettings.json` containing the JWT signing
+secret, the bcrypt admin password hash, the CurseForge API key and the webhook
+URL. It is written via `ObjectMapper.writeValue(file, …)`, which creates the file
+with the process umask (typically `0644`, group/world-readable).
+
+On Linux the installer creates `/etc/moddex` as `0750 root:moddex`, which limits
+exposure, but the secrets file itself is not restricted, and the service also
+re-creates the directory at runtime (`Files.createDirectories`) without an
+explicit mode. Defense in depth: the file should be owner-only (`0600`).
+
+**Recommendation / fix:** after writing, set POSIX permissions `rw-------` on the
+settings file (skip gracefully on non-POSIX/Windows). Implemented in the backend.
+
+### B2 — Unconditional trust of forwarded client IP (Medium)
+
+`application.yml` sets `server.forward-headers-strategy: framework`, so
+`request.remoteAddr` reflects client-supplied `X-Forwarded-For`. Behind a
+properly configured reverse proxy this is correct, but in `public` mode exposed
+directly (the installer permits `--mode public` binding `0.0.0.0`) an attacker
+can spoof the header to evade the login rate-limiter (keyed on `remoteAddr`) and
+forge audit-log client IPs.
+
+**Recommendation:** require a header-sanitising reverse proxy for `public` mode,
+and/or make forwarded-header trust opt-in via a trusted-proxy setting. Needs a
+design decision — tracked in [#47](https://github.com/aklozyp/Moddex/issues/47).
+
+### Strengths confirmed
+
+- **Modpack import** (`ModpackImportSecurity`): path traversal, absolute/drive
+  paths, reserved names and control chars rejected; `resolveWithin` re-checks the
+  resolved path stays inside the instance dir; HTTPS host allowlist; mandatory
+  integrity hashes; per-file/total size and count ceilings with a zip-bomb guard.
+- **Artifact download** (`SecureArtifactDownloader`): HTTPS + host allowlist,
+  manual redirects re-validated at every hop and bounded, streaming hash, copy
+  aborted mid-flight past the byte cap, atomic move, temp cleanup on failure.
+- **Auth**: bcrypt, `LoginAttemptService` rate-limiting, audit logging, stateless
+  JWT (HS256, 256-bit `SecureRandom` secret), CSRF disabled appropriately for a
+  token (non-cookie) API.
+- **CORS**: fail-closed for `lan`/`public`, credentials disabled.
+- **Error responses**: messages, stack traces and binding errors never returned.
+
+### B3 — Console WebSocket token in query param (Info)
+
+Browsers cannot set the `Authorization` header on a WebSocket handshake, so the
+console authenticates via a token query parameter. Tokens in URLs can be captured
+by intermediary access logs. Accepted trade-off; mitigated by short token
+lifetime and TLS at the proxy.
+
+---
+
+## Frontend
+
+### F1 — Unused `SafeHtmlPipe` footgun (Low)
+
+`src/app/pipes/safe-html.pipe.ts` calls `DomSanitizer.bypassSecurityTrustHtml`.
+It is imported in `mod-detail-page.component.ts` but **not used in any template**.
+The one `[innerHTML]` binding (`project.body | markdown`) passes a plain string,
+so Angular's built-in sanitiser runs — that path is safe. The unused bypass pipe
+is a latent hazard if later applied to untrusted content.
+
+**Recommendation / fix:** remove the pipe and its import. Implemented.
+
+### F2 — No Content-Security-Policy (Low)
+
+`index.html` ships no CSP. A CSP is meaningful defense in depth against XSS even
+with Angular's sanitiser (it would blunt an accidental future bypass and block
+unexpected origins).
+
+**Recommendation / fix:** add a restrictive CSP `<meta>` (self-only scripts/
+styles, images from self/data, connect to self). Implemented.
+
+### F3 — JWT in `localStorage` (Info)
+
+The bearer token lives in `localStorage`, readable by any script in the origin.
+This is the pragmatic choice for a header-based (non-cookie) API and is acceptable
+given the sanitiser and the CSP added in F2. Documented trade-off.
+
+---
+
+## Build / Packaging / CI
+
+### C1 — Missing least-privilege `permissions` (Medium → Fixed)
+
+`ci.yml` and `smoke.yml` declared no `permissions`, inheriting the repository
+default `GITHUB_TOKEN` scope. Both only read code and build. Added
+`permissions: contents: read`. (`release.yml` already scopes `contents: write`
+per job.)
+
+### C2 — Actions pinned by tag, not SHA (Low — recommendation)
+
+Workflows reference `actions/checkout@v4`, `softprops/action-gh-release@v2`, etc.
+A compromised tag could inject malicious action code. Pinning to full commit SHAs
+(especially for the third-party `softprops/action-gh-release`) removes that risk.
+Left as a recommendation to avoid mass churn; Dependabot (C4) keeps the pins
+current once applied.
+
+### C3 — No SECURITY.md (Low → Fixed)
+
+Added `SECURITY.md` with a private vulnerability-reporting policy (referenced by
+`SUPPORT.md` and the issue-template config).
+
+### C4 — No dependency scanning (Low → Fixed here, follow-up for app repos)
+
+Added `.github/dependabot.yml` for the GitHub Actions ecosystem in this repo.
+Equivalent Maven (backend) and npm (frontend) Dependabot configs should be added
+in those repositories.
+
+### Strengths confirmed
+
+- Linux installer writes `moddex.env` with `umask 027` (`0640 root:moddex`),
+  config dir `0750`, secrets not world-readable; idempotent upgrades preserve
+  operator config.
+- WinSW is checksum-pinned in both the installer and the bundle builder.
+- Release artifacts ship SHA-256 checksums; downloads verify them.
+
+---
+
+## Remediation tracking
+
+| Finding | Where |
+|---------|-------|
+| B1 | Backend PR (this review) |
+| F1, F2 | Frontend PR (this review) |
+| C1, C3, C4 | This (meta) PR |
+| B2 | [#47](https://github.com/aklozyp/Moddex/issues/47) |
+| C2 | Recommendation — apply with Dependabot follow-up |
+| B3, F3 | Accepted, documented |


### PR DESCRIPTION
Implements the meta-repo portion of the v0.4 security review (#46).

## What
- **Report:** `docs/qa/security-review.md` — manual review across backend, frontend and CI.
- **C1:** least-privilege `permissions: contents: read` on `ci.yml` and `smoke.yml`.
- **C3:** `SECURITY.md` private vulnerability-reporting policy.
- **C4:** Dependabot config for GitHub Actions (Maven/npm equivalents land in the app repos).
- README + CHANGELOG reference the review and policy.

## Findings split out
- **B1** (backend secrets file perms): separate Moddex-Backend PR.
- **F1/F2** (frontend SafeHtmlPipe / CSP): separate Moddex-Frontend PR.
- **B2** (X-Forwarded-For trust): tracked in #47.

Base `develop` per repo convention; closes the meta part of #46 (issue stays open until backend/frontend fixes merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)