### PR TITLE
docs(security): record B2 fix + harden reverse-proxy guidance (#46/#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,8 +309,11 @@ server {
         proxy_pass         http://127.0.0.1:8080;
         proxy_set_header   Host $host;
         proxy_set_header   X-Real-IP $remote_addr;
-        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        # Overwrite (do NOT append) so a client cannot inject a spoofed leftmost
+        # entry, and clear the RFC Forwarded header the backend also honours.
+        proxy_set_header   X-Forwarded-For $remote_addr;
         proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Forwarded "";
     }
 
     # Statische Frontend-Assets direkt ausliefern (optional, performanter)
@@ -327,6 +330,13 @@ server {
 ```
 
 Für Caddy ist `reverse_proxy localhost:8080` mit automatischem TLS über Let's Encrypt ausreichend.
+
+Damit das Backend die echte Client-IP (für Login-Rate-Limit und Audit-Log) aus
+dem Proxy übernimmt, muss `MODDEX_FORWARD_HEADERS_STRATEGY=framework` gesetzt
+sein — **nur** hinter einem Proxy, der wie oben *alle* Forwarded-Header
+überschreibt/leert. Ohne Proxy (Direkt-Exposition) bleibt der sichere Default
+`none`, sonst könnten Clients ihre IP fälschen. Siehe
+`Moddex-Backend/docs/security-configuration.md`.
 
 ### Backup
 

--- a/docs/qa/security-review.md
+++ b/docs/qa/security-review.md
@@ -28,7 +28,7 @@ gaps and several Low/Info hardening items.
 | ID | Severity | Area | Finding | Status |
 |----|----------|------|---------|--------|
 | B1 | Medium | Backend | `serversettings.json` (JWT secret, admin hash, API key) written with default file permissions | **Fixed** — backend PR |
-| B2 | Medium | Backend | `X-Forwarded-For` trusted unconditionally → IP spoofing when directly exposed in `public` mode | Tracked — [#47](https://github.com/aklozyp/Moddex/issues/47) |
+| B2 | Medium | Backend | `X-Forwarded-For` trusted unconditionally → IP spoofing when directly exposed in `public` mode | **Fixed** — backend PR ([#47](https://github.com/aklozyp/Moddex/issues/47)) |
 | F1 | Low | Frontend | Unused `SafeHtmlPipe` (`bypassSecurityTrustHtml`) — latent XSS footgun | **Fixed** — frontend PR |
 | F2 | Low | Frontend | No Content-Security-Policy | **Fixed** — frontend PR |
 | C1 | Medium | CI | `ci.yml`/`smoke.yml` had no least-privilege `permissions` | **Fixed** — this PR |
@@ -57,7 +57,7 @@ explicit mode. Defense in depth: the file should be owner-only (`0600`).
 **Recommendation / fix:** after writing, set POSIX permissions `rw-------` on the
 settings file (skip gracefully on non-POSIX/Windows). Implemented in the backend.
 
-### B2 — Unconditional trust of forwarded client IP (Medium)
+### B2 — Unconditional trust of forwarded client IP (Medium → Fixed)
 
 `application.yml` sets `server.forward-headers-strategy: framework`, so
 `request.remoteAddr` reflects client-supplied `X-Forwarded-For`. Behind a
@@ -66,9 +66,13 @@ directly (the installer permits `--mode public` binding `0.0.0.0`) an attacker
 can spoof the header to evade the login rate-limiter (keyed on `remoteAddr`) and
 forge audit-log client IPs.
 
-**Recommendation:** require a header-sanitising reverse proxy for `public` mode,
-and/or make forwarded-header trust opt-in via a trusted-proxy setting. Needs a
-design decision — tracked in [#47](https://github.com/aklozyp/Moddex/issues/47).
+**Fixed:** `forward-headers-strategy` now defaults to `none` — the client IP
+comes from the direct socket and forwarded headers are not trusted. Operators
+behind a reverse proxy that overwrites/clears *all* forwarded headers opt back
+in via `MODDEX_FORWARD_HEADERS_STRATEGY=framework`
+(see `Moddex-Backend/docs/security-configuration.md` and the reverse-proxy
+section in this README). Tracked in
+[#47](https://github.com/aklozyp/Moddex/issues/47).
 
 ### Strengths confirmed
 
@@ -148,8 +152,8 @@ Added `SECURITY.md` with a private vulnerability-reporting policy (referenced by
 ### C4 — No dependency scanning (Low → Fixed here, follow-up for app repos)
 
 Added `.github/dependabot.yml` for the GitHub Actions ecosystem in this repo.
-Equivalent Maven (backend) and npm (frontend) Dependabot configs should be added
-in those repositories.
+Equivalent Maven (backend) and npm (frontend) Dependabot configs were added in
+those repositories alongside the B1 and F1/F2 fixes.
 
 ### Strengths confirmed
 
@@ -168,6 +172,6 @@ in those repositories.
 | B1 | Backend PR (this review) |
 | F1, F2 | Frontend PR (this review) |
 | C1, C3, C4 | This (meta) PR |
-| B2 | [#47](https://github.com/aklozyp/Moddex/issues/47) |
+| B2 | Backend PR ([#47](https://github.com/aklozyp/Moddex/issues/47)) |
 | C2 | Recommendation — apply with Dependabot follow-up |
 | B3, F3 | Accepted, documented |


### PR DESCRIPTION
Documentation follow-up to the security review now that B2/#47 is fixed and the C4 app-repo Dependabot configs have landed.

- **security-review.md:** B2 (X-Forwarded-For trust) marked **Fixed** (backend #47); C4 notes the Maven/npm Dependabot configs were added in the app repos.
- **README reverse-proxy example:** overwrite `X-Forwarded-For` with `$remote_addr` instead of the appending `$proxy_add_x_forwarded_for`, and clear the RFC `Forwarded` header (which Spring's `framework` strategy also honours). Notes that `MODDEX_FORWARD_HEADERS_STRATEGY=framework` is required — and only safe — behind such a proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)