### PR TITLE
ci: Actions auf Commit-SHAs gepinnt (#52, Security-Review C2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout packaging repo (Moddex-build)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -55,7 +55,7 @@ jobs:
           path: Moddex-build
 
       - name: Checkout backend repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex-Backend
           ref: tests
@@ -63,7 +63,7 @@ jobs:
           path: Moddex-Backend
 
       - name: Checkout frontend repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex-Frontend
           ref: tests
@@ -71,14 +71,14 @@ jobs:
           path: Moddex-Frontend
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: '21'
           cache: maven
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -101,7 +101,7 @@ jobs:
           Moddex-build/scripts/build-bundle.sh
 
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: moddex-bundle-${{ matrix.os }}
           path: |
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: Checkout packaging repo (Moddex-build)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -129,7 +129,7 @@ jobs:
           path: Moddex-build
 
       - name: Checkout backend repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex-Backend
           ref: tests
@@ -137,7 +137,7 @@ jobs:
           path: Moddex-Backend
 
       - name: Checkout frontend repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex-Frontend
           ref: tests
@@ -145,14 +145,14 @@ jobs:
           path: Moddex-Frontend
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: '21'
           cache: maven
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -163,7 +163,7 @@ jobs:
         run: Moddex-build/scripts/windows/build-bundle.ps1 -Version $env:VERSION
 
       - name: Upload Windows bundle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: moddex-bundle-windows
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       # Check out the three repositories into the sibling layout that
       # build-bundle.sh expects (REPO_ROOT/{Moddex-build,Moddex-Backend,Moddex-Frontend}).
       - name: Checkout packaging repo (Moddex-build)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex
           ref: ${{ env.TARGET_REF }}
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout backend repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex-Backend
           ref: ${{ env.TARGET_REF }}
@@ -59,7 +59,7 @@ jobs:
           path: Moddex-Backend
 
       - name: Checkout frontend repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex-Frontend
           ref: ${{ env.TARGET_REF }}
@@ -67,14 +67,14 @@ jobs:
           path: Moddex-Frontend
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: '21'
           cache: maven
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -105,7 +105,7 @@ jobs:
         run: sha256sum -c "moddex-${TARGET_REF}-linux-amd64.tar.gz.sha256"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ env.TARGET_REF }}
           # Auto-generate the notes body from merged PRs, grouped per
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout packaging repo (Moddex-build)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex
           ref: ${{ env.TARGET_REF }}
@@ -139,7 +139,7 @@ jobs:
           path: Moddex-build
 
       - name: Checkout backend repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex-Backend
           ref: ${{ env.TARGET_REF }}
@@ -147,7 +147,7 @@ jobs:
           path: Moddex-Backend
 
       - name: Checkout frontend repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex-Frontend
           ref: ${{ env.TARGET_REF }}
@@ -155,14 +155,14 @@ jobs:
           path: Moddex-Frontend
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: '21'
           cache: maven
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -187,7 +187,7 @@ jobs:
           Copy-Item "Moddex-build/build/moddex-$env:TARGET_REF-windows-x64.zip.sha256" .
 
       - name: Attach to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ env.TARGET_REF }}
           files: |

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -41,14 +41,14 @@ jobs:
 
     steps:
       - name: Checkout packaging repo (Moddex-build)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex
           token: ${{ env.CHECKOUT_TOKEN }}
           path: Moddex-build
 
       - name: Checkout backend repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex-Backend
           ref: ${{ inputs.backend_ref }}
@@ -56,7 +56,7 @@ jobs:
           path: Moddex-Backend
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: '21'

--- a/docs/qa/security-review.md
+++ b/docs/qa/security-review.md
@@ -32,7 +32,7 @@ gaps and several Low/Info hardening items.
 | F1 | Low | Frontend | Unused `SafeHtmlPipe` (`bypassSecurityTrustHtml`) — latent XSS footgun | **Fixed** — frontend PR |
 | F2 | Low | Frontend | No Content-Security-Policy | **Fixed** — frontend PR |
 | C1 | Medium | CI | `ci.yml`/`smoke.yml` had no least-privilege `permissions` | **Fixed** — this PR |
-| C2 | Low | CI | Actions pinned by mutable tag, not commit SHA | Recommendation (below) |
+| C2 | Low | CI | Actions pinned by mutable tag, not commit SHA | **Fixed** — [#52](https://github.com/aklozyp/Moddex/issues/52) |
 | C3 | Low | Repo | No `SECURITY.md` disclosure policy | **Fixed** — this PR |
 | C4 | Low | Repo | No Dependabot / dependency scanning | **Fixed** (meta) — this PR |
 | B3 | Info | Backend | Console WebSocket auth via token query param | Accepted (documented) |
@@ -136,13 +136,17 @@ default `GITHUB_TOKEN` scope. Both only read code and build. Added
 `permissions: contents: read`. (`release.yml` already scopes `contents: write`
 per job.)
 
-### C2 — Actions pinned by tag, not SHA (Low — recommendation)
+### C2 — Actions pinned by tag, not SHA (Low → Fixed)
 
-Workflows reference `actions/checkout@v4`, `softprops/action-gh-release@v2`, etc.
-A compromised tag could inject malicious action code. Pinning to full commit SHAs
-(especially for the third-party `softprops/action-gh-release`) removes that risk.
-Left as a recommendation to avoid mass churn; Dependabot (C4) keeps the pins
-current once applied.
+Workflows referenced `actions/checkout@v4`, `softprops/action-gh-release@v2`,
+etc. A compromised tag could inject malicious action code with access to
+`MODDEX_CHECKOUT_TOKEN`. Pinning to full commit SHAs (especially for the
+third-party `softprops/action-gh-release`) removes that risk.
+
+**Fixed** ([#52](https://github.com/aklozyp/Moddex/issues/52)): every `uses:`
+in `ci.yml`, `smoke.yml` and `release.yml` is pinned to the full commit SHA of
+the previously used version tag (annotated `# v4`/`# v2`). Dependabot (C4)
+keeps the pins current.
 
 ### C3 — No SECURITY.md (Low → Fixed)
 


### PR DESCRIPTION
Issue #52 — Umsetzung der offenen Security-Review-Empfehlung C2.

Jedes `uses:` in `ci.yml`, `smoke.yml` und `release.yml` referenziert jetzt den vollen Commit-SHA des bisher verwendeten Version-Tags (kommentiert mit `# v4`/`# v2`, kein Versions-Upgrade — das übernimmt Dependabot). Ein kompromittierter Action-Tag kann damit keinen Code mehr mit Zugriff auf `MODDEX_CHECKOUT_TOKEN` einschleusen. `docs/qa/security-review.md`: C2 auf **Fixed** gesetzt.

Gepinnt: actions/checkout, setup-java, setup-node, upload-artifact (je v4-Tag-SHA), softprops/action-gh-release (v2-Tag-SHA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)