### PR TITLE
ci: Cross-Repo-Refs parametrisieren + Smoke-Test als Release-Gate (#53)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,29 @@ on:
   pull_request:
     branches: [develop, tests, main]
   workflow_dispatch:
+    inputs:
+      backend_ref:
+        description: 'Moddex-Backend ref (branch, tag or SHA). Empty = branch default (main -> main, else tests).'
+        required: false
+        default: ''
+        type: string
+      frontend_ref:
+        description: 'Moddex-Frontend ref (branch, tag or SHA). Empty = branch default (main -> main, else tests).'
+        required: false
+        default: ''
+        type: string
 
 concurrency:
   group: moddex-ci-${{ github.ref }}
   cancel-in-progress: true
+
+# Cross-repo refs (#53): builds validating `main` of this repo check out `main`
+# of the app repos (reproducible release-line builds); everything else tracks
+# the app repos' integration branch `tests`. workflow_dispatch can override
+# both. The resolved refs + SHAs are written to the job summary.
+env:
+  BACKEND_REF: ${{ inputs.backend_ref || ((github.base_ref || github.ref_name) == 'main' && 'main' || 'tests') }}
+  FRONTEND_REF: ${{ inputs.frontend_ref || ((github.base_ref || github.ref_name) == 'main' && 'main' || 'tests') }}
 
 # Least privilege: this workflow only checks out code and builds. It never writes
 # to the repo, so the default GITHUB_TOKEN is dropped to read-only. (The private
@@ -58,7 +77,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex-Backend
-          ref: tests
+          ref: ${{ env.BACKEND_REF }}
           token: ${{ env.CHECKOUT_TOKEN }}
           path: Moddex-Backend
 
@@ -66,9 +85,21 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex-Frontend
-          ref: tests
+          ref: ${{ env.FRONTEND_REF }}
           token: ${{ env.CHECKOUT_TOKEN }}
           path: Moddex-Frontend
+
+      - name: Record checked-out refs in job summary
+        shell: bash
+        run: |
+          {
+            echo "### Checked-out refs"
+            echo "| Repo | Ref | SHA |"
+            echo "|------|-----|-----|"
+            echo "| Moddex-build | \`${{ github.event.pull_request.head.sha || github.sha }}\` | \`$(git -C Moddex-build rev-parse HEAD)\` |"
+            echo "| Moddex-Backend | \`${BACKEND_REF}\` | \`$(git -C Moddex-Backend rev-parse HEAD)\` |"
+            echo "| Moddex-Frontend | \`${FRONTEND_REF}\` | \`$(git -C Moddex-Frontend rev-parse HEAD)\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Set up Java
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
@@ -132,7 +163,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex-Backend
-          ref: tests
+          ref: ${{ env.BACKEND_REF }}
           token: ${{ env.CHECKOUT_TOKEN }}
           path: Moddex-Backend
 
@@ -140,9 +171,21 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: aklozyp/Moddex-Frontend
-          ref: tests
+          ref: ${{ env.FRONTEND_REF }}
           token: ${{ env.CHECKOUT_TOKEN }}
           path: Moddex-Frontend
+
+      - name: Record checked-out refs in job summary
+        shell: bash
+        run: |
+          {
+            echo "### Checked-out refs"
+            echo "| Repo | Ref | SHA |"
+            echo "|------|-----|-----|"
+            echo "| Moddex-build | \`${{ github.event.pull_request.head.sha || github.sha }}\` | \`$(git -C Moddex-build rev-parse HEAD)\` |"
+            echo "| Moddex-Backend | \`${BACKEND_REF}\` | \`$(git -C Moddex-Backend rev-parse HEAD)\` |"
+            echo "| Moddex-Frontend | \`${FRONTEND_REF}\` | \`$(git -C Moddex-Frontend rev-parse HEAD)\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Set up Java
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: release
 
-# Tag-driven release pipeline. Builds the backend JAR and the frontend bundle
-# from the three Moddex repositories, assembles the installable Linux artifact
-# with a SHA256 checksum and publishes a GitHub Release.
+# Tag-driven release pipeline. Runs the release smoke test as a mandatory gate
+# (#53), then builds the backend JAR and the frontend bundle from the three
+# Moddex repositories, assembles the installable Linux artifact with a SHA256
+# checksum and publishes a GitHub Release.
 #
 # Cross-repo checkout: aklozyp/Moddex is public, but Moddex-Backend and
 # Moddex-Frontend are private, so the default GITHUB_TOKEN cannot read them. Set
@@ -30,7 +31,19 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Mandatory pre-release gate (#53): the release smoke test (build + boot the
+  # backend, run scripts/release-smoke-test.sh) must pass before any release
+  # artifact is built. Reuses smoke.yml against the release ref.
+  smoke:
+    uses: ./.github/workflows/smoke.yml
+    with:
+      backend_ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+    secrets: inherit
+    permissions:
+      contents: read
+
   build-package:
+    needs: smoke
     runs-on: ubuntu-22.04
     permissions:
       contents: write   # required for release upload

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,8 +1,12 @@
 name: smoke
 
-# Manual pre-release smoke test. Builds and boots the backend on loopback with a
+# Pre-release smoke test. Builds and boots the backend on loopback with a
 # throwaway data directory, then runs scripts/release-smoke-test.sh against it.
 # See docs/qa/release-checklist.md.
+#
+# Runs manually (workflow_dispatch) and as a reusable workflow: release.yml
+# calls it as a mandatory gate before building release artifacts (#53), so
+# every v* tag is smoke-tested automatically.
 #
 # Cross-repo checkout: Moddex-Backend is private, so set MODDEX_CHECKOUT_TOKEN
 # (see docs/ci.md). By default the instance-create + backup steps are skipped
@@ -18,6 +22,16 @@ on:
         type: boolean
       backend_ref:
         description: 'Moddex-Backend ref to build & test (branch, tag or SHA). Set to the release candidate when gating a release.'
+        required: false
+        default: tests
+        type: string
+  workflow_call:
+    inputs:
+      full:
+        required: false
+        default: false
+        type: boolean
+      backend_ref:
         required: false
         default: tests
         type: string

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -34,6 +34,21 @@ permission error.
 Triggers: push and pull requests to `develop`, `tests`, `main`, plus manual
 dispatch.
 
+### Cross-repo refs
+
+The backend/frontend checkouts are resolved per branch
+([#53](https://github.com/aklozyp/Moddex/issues/53)): builds validating `main`
+of this repo check out `main` of the app repos (reproducible release-line
+builds); every other branch tracks the app repos' integration branch `tests`.
+Manual dispatch accepts explicit `backend_ref`/`frontend_ref` overrides. The
+resolved refs and their commit SHAs are recorded in the job summary of every
+run.
+
+The app repos additionally run their own slim test workflows on every push/PR
+(`Moddex-Backend`: `mvnw -Pci test`; `Moddex-Frontend`: headless unit tests,
+theme-contrast audit and AOT production build), so changes there are validated
+without waiting for this repo's bundle build.
+
 For every change it runs, across a runner matrix:
 
 - backend tests (`mvnw -Pci test`),
@@ -69,8 +84,13 @@ All three repositories must carry the release tag (or you pass the ref via
 runner so the artifact links against the oldest still-supported glibc and runs
 on the broadest range of Debian/Ubuntu targets.
 
-Steps: checkout all three repos at the tag → backend tests → `build-bundle.sh`
-→ verify the SHA256 checksum → publish a GitHub Release with:
+The release smoke test (`smoke.yml`, called as a reusable workflow) runs first
+as a **mandatory gate** ([#53](https://github.com/aklozyp/Moddex/issues/53)):
+no release artifact is built unless the backend boots and passes
+`scripts/release-smoke-test.sh` at the release ref.
+
+Steps: smoke gate → checkout all three repos at the tag → backend tests →
+`build-bundle.sh` → verify the SHA256 checksum → publish a GitHub Release with:
 
 - `moddex-<tag>-linux-amd64.tar.gz` (versioned bundle),
 - `moddex-<tag>-linux-amd64.tar.gz.sha256`,


### PR DESCRIPTION
Teil von aklozyp/Moddex#53 (Meta-Anteil).

## Was

1. **`ci.yml` — Cross-Repo-Refs parametrisiert:** Backend/Frontend werden nicht mehr hart auf `tests` ausgecheckt. Auflösung pro Branch: Builds für `main` dieses Repos → `main` der App-Repos (reproduzierbare Release-Linie), alles andere → `tests`. `workflow_dispatch` bietet explizite `backend_ref`/`frontend_ref`-Overrides. Beide Jobs schreiben die aufgelösten Refs + Commit-SHAs in das Job-Summary.
2. **`smoke.yml` — als reusable Workflow geöffnet** (`workflow_call` mit denselben Inputs `full`/`backend_ref`).
3. **`release.yml` — Smoke-Test als Pflicht-Gate:** neuer Job `smoke` (ruft `smoke.yml` mit dem Release-Ref auf), `build-package` hängt per `needs` daran. Damit wird jeder `v*`-Tag automatisch gesmoke-testet, bevor Artefakte gebaut werden.
4. **`docs/ci.md`** entsprechend aktualisiert.

Die schlanken Test-Workflows in den App-Repos (Punkt 2 des Issues) laufen als eigene PRs: aklozyp/Moddex-Backend (Branch `ai/backend/meta-issue-53`) und aklozyp/Moddex-Frontend (Branch `ai/frontend/meta-issue-53`), jeweils inkl. `github-actions`-Dependabot für die SHA-Pins.

## Verifikation

Alle drei geänderten Workflow-Dateien mit js-yaml geparst (syntaktisch valide); Ref-Auflösung nutzt nur `github.base_ref`/`github.ref_name`/`inputs` (in `env` auf Workflow-Ebene erlaubt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
