### PR TITLE
fix(ci): Schreibbare Moddex-Verzeichnisse in Backend-Test-Steps (Moddex-Backend#55)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,14 @@ jobs:
           cache-dependency-path: 'Moddex-Frontend/package-lock.json'
 
       - name: Backend tests
+        # Writable Moddex dirs: the context-load test boots the full app, whose
+        # JwtService persists its secret into the config dir (default
+        # /etc/moddex, not writable on hosted runners). Mirrors smoke.yml
+        # (Moddex-Backend#55).
+        env:
+          MODDEX_ROOT: ${{ runner.temp }}/moddex-data
+          MODDEX_CONFIG_DIR: ${{ runner.temp }}/moddex-cfg
+          MODDEX_LOG_DIR: ${{ runner.temp }}/moddex-log
         run: |
           chmod +x Moddex-Backend/mvnw
           Moddex-Backend/mvnw -f Moddex-Backend/pom.xml -B -Pci test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,11 @@ jobs:
       # Fast confidence check before producing a release artifact. The full test
       # matrix runs in ci.yml; here we re-run the no-network backend tests only.
       - name: Run backend tests
+        # Writable Moddex dirs for the full-context test (Moddex-Backend#55).
+        env:
+          MODDEX_ROOT: ${{ runner.temp }}/moddex-data
+          MODDEX_CONFIG_DIR: ${{ runner.temp }}/moddex-cfg
+          MODDEX_LOG_DIR: ${{ runner.temp }}/moddex-log
         run: |
           chmod +x Moddex-Backend/mvnw
           Moddex-Backend/mvnw -f Moddex-Backend/pom.xml -B -Pci test


### PR DESCRIPTION
Follow-up zu #53/#55: dieselben Env-Vars wie in smoke.yml auch fuer die Backend-Test-Steps in ci.yml und release.yml, damit der Full-Context-Test (JwtService schreibt ins Config-Verzeichnis) auf Hosted-Runnern laeuft.