### PR TITLE
fix(windows): -Mode/-Port Explizitheit auf Skriptebene ermitteln (#57)

### DIFF
--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -43,6 +43,15 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# Which parameters the caller actually supplied, captured HERE and nowhere else.
+# Inside a function $PSBoundParameters describes that function's own parameters,
+# so a function asking `$PSBoundParameters.ContainsKey('Mode')` always got $false
+# and an explicit -Mode/-Port was silently discarded (#57). Explicitness is a
+# property of the script invocation; it is determined once, at script scope, and
+# passed down.
+$ModeExplicit = $PSBoundParameters.ContainsKey('Mode')
+$PortExplicit = $PSBoundParameters.ContainsKey('Port')
+
 # --- constants ---------------------------------------------------------------
 $ServiceId   = 'moddex-backend'
 $AppDir      = Join-Path $env:ProgramFiles 'Moddex'
@@ -96,15 +105,23 @@ function Resolve-JavaExe {
 }
 
 # --- WinSW acquisition -------------------------------------------------------
+# Takes the operator-supplied path as a parameter instead of reading it from the
+# enclosing scope. The scope-visibility shortcut is what made #57 possible; the
+# same pattern is not left in place here.
 function Resolve-WinSw {
-    $bundled = if ($WinSwPath) { $WinSwPath } else { Join-Path $PackagingWin 'WinSW.exe' }
+    param([string] $RequestedPath)
+
+    $bundled = if ($RequestedPath) { $RequestedPath } else { Join-Path $PackagingWin 'WinSW.exe' }
     if (Test-Path $bundled) {
         Write-Log "Using bundled WinSW: $bundled"
         return $bundled
     }
+    if ($RequestedPath) {
+        Die "WinSW not found at the path given via -WinSwPath: $RequestedPath"
+    }
     # Not bundled: download the pinned release and verify its hash.
     $tmp = Join-Path $env:TEMP "WinSW-$WinSwVersion.exe"
-    Write-Log "Downloading WinSW $WinSwVersion …"
+    Write-Log "Downloading WinSW $WinSwVersion ..."
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     Invoke-WebRequest -Uri $WinSwUrl -OutFile $tmp -UseBasicParsing
     $actual = (Get-FileHash -Algorithm SHA256 -Path $tmp).Hash.ToLowerInvariant()
@@ -146,21 +163,35 @@ function Get-UnmanagedEnv {
     return $kept
 }
 
+# Resolves the effective mode/port. Explicitness is passed in rather than
+# inferred, because it cannot be observed from here (see the note at the top of
+# the script). An explicitly supplied value always wins over an inherited one;
+# only an omitted parameter falls back to the existing installation, and only
+# then to the default.
 function Resolve-Config {
-    $modeExplicit = $PSBoundParameters.ContainsKey('Mode')
-    $portExplicit = $PSBoundParameters.ContainsKey('Port')
+    param(
+        [string] $RequestedMode,
+        [int]    $RequestedPort,
+        [bool]   $ModeWasGiven,
+        [bool]   $PortWasGiven
+    )
 
-    $resolvedMode = $Mode
-    if (-not $modeExplicit) {
+    if ($ModeWasGiven) {
+        $resolvedMode = $RequestedMode
+    } else {
         $existingMode = Get-ExistingEnv 'MODDEX_MODE'
-        if ($existingMode) { $resolvedMode = $existingMode }
-        elseif (-not $resolvedMode) {
+        if ($existingMode) {
+            $resolvedMode = $existingMode
+        } elseif ($RequestedMode) {
+            $resolvedMode = $RequestedMode
+        } else {
             Die 'No -Mode given and no existing install to inherit from. Pass -Mode local|lan|public.'
         }
     }
 
-    $resolvedPort = $Port
-    if (-not $portExplicit) {
+    if ($PortWasGiven) {
+        $resolvedPort = $RequestedPort
+    } else {
         $existingPort = Get-ExistingEnv 'SERVER_PORT'
         if ($existingPort) { $resolvedPort = [int]$existingPort } else { $resolvedPort = 8080 }
     }
@@ -180,7 +211,8 @@ if (-not $FrontendDir) { $FrontendDir = Join-Path $BundleRoot 'frontend' }
 if (-not (Test-Path $BackendJar))  { Die "Backend JAR not found: $BackendJar" }
 if (-not (Test-Path $FrontendDir)) { Die "Frontend assets not found: $FrontendDir" }
 
-$cfg = Resolve-Config
+$cfg = Resolve-Config -RequestedMode $Mode -RequestedPort $Port `
+    -ModeWasGiven $ModeExplicit -PortWasGiven $PortExplicit
 Write-Log "Mode=$($cfg.Mode) Address=$($cfg.Address) Port=$($cfg.Port)"
 
 # Public mode serves plain HTTP unless the operator sets up TLS (reverse proxy
@@ -208,11 +240,11 @@ foreach ($dir in @($AppDir, $DataDir, $ConfigDir, $LogDir)) {
 
 # Stop the service before replacing the JAR so the file is not locked.
 if (Get-Service -Name $ServiceId -ErrorAction SilentlyContinue) {
-    Write-Log 'Stopping existing service for upgrade …'
+    Write-Log 'Stopping existing service for upgrade ...'
     & $ServiceExe stop  2>$null | Out-Null
 }
 
-Write-Log 'Installing application artifacts …'
+Write-Log 'Installing application artifacts ...'
 Copy-Item -Path $BackendJar -Destination (Join-Path $AppDir 'app.jar') -Force
 $frontendTarget = Join-Path $AppDir 'frontend'
 if (Test-Path $frontendTarget) { Remove-Item -Recurse -Force $frontendTarget }
@@ -234,14 +266,28 @@ if (Test-Path $bundleVersion) {
 $templatePath = Join-Path $PackagingWin 'moddex-backend.xml.template'
 if (-not (Test-Path $templatePath)) { Die "Service template not found: $templatePath" }
 $xml = Get-Content -Path $templatePath -Raw
-$xml = $xml.Replace('@@JAVA_EXE@@', $javaExe).
-            Replace('@@APP_DIR@@', $AppDir).
-            Replace('@@DATA_DIR@@', $DataDir).
-            Replace('@@CONFIG_DIR@@', $ConfigDir).
-            Replace('@@LOG_DIR@@', $LogDir).
-            Replace('@@MODE@@', $cfg.Mode).
-            Replace('@@SERVER_ADDRESS@@', $cfg.Address).
-            Replace('@@SERVER_PORT@@', [string]$cfg.Port)
+
+# Placeholder table rather than a chained .Replace(): adding a placeholder is one
+# line, and the substitutions are visible as data instead of buried in a chain.
+$substitutions = [ordered]@{
+    '@@JAVA_EXE@@'       = $javaExe
+    '@@APP_DIR@@'        = $AppDir
+    '@@DATA_DIR@@'       = $DataDir
+    '@@CONFIG_DIR@@'     = $ConfigDir
+    '@@LOG_DIR@@'        = $LogDir
+    '@@MODE@@'           = $cfg.Mode
+    '@@SERVER_ADDRESS@@' = $cfg.Address
+    '@@SERVER_PORT@@'    = [string]$cfg.Port
+}
+foreach ($placeholder in $substitutions.Keys) {
+    $xml = $xml.Replace($placeholder, $substitutions[$placeholder])
+}
+
+# An unresolved placeholder would be written into the service definition and only
+# fail when the service refuses to start, so catch it here.
+if ($xml -match '@@[A-Z_]+@@') {
+    Die "Service template still contains an unresolved placeholder: $($Matches[0])"
+}
 
 # Re-render replaces the whole file, so carry over any operator-added <env>
 # entries from the previous definition before writing (read while the old XML is
@@ -263,15 +309,15 @@ if ($preservedEnv.Count -gt 0) {
 
 # Place the WinSW executable next to its XML (WinSW derives the config from its
 # own file name: moddex-backend.exe -> moddex-backend.xml).
-Copy-Item -Path (Resolve-WinSw) -Destination $ServiceExe -Force
+Copy-Item -Path (Resolve-WinSw -RequestedPath $WinSwPath) -Destination $ServiceExe -Force
 
 # (Re)install and start the service.
 if (Get-Service -Name $ServiceId -ErrorAction SilentlyContinue) {
-    Write-Log 'Updating service registration …'
+    Write-Log 'Updating service registration ...'
     & $ServiceExe uninstall | Out-Null
     Start-Sleep -Seconds 1
 }
-Write-Log 'Registering Windows service …'
+Write-Log 'Registering Windows service ...'
 & $ServiceExe install | Out-Null
 & $ServiceExe start   | Out-Null
 

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -284,8 +284,12 @@ foreach ($placeholder in $substitutions.Keys) {
 }
 
 # An unresolved placeholder would be written into the service definition and only
-# fail when the service refuses to start, so catch it here.
-if ($xml -match '@@[A-Z_]+@@') {
+# fail when the service refuses to start, so catch it here. The check runs over
+# the XML with comments stripped: the template's own header comment describes the
+# mechanism using the literal "@@PLACEHOLDERS@@", which is documentation, not a
+# substitution site.
+$xmlWithoutComments = [regex]::Replace($xml, '(?s)<!--.*?-->', '')
+if ($xmlWithoutComments -match '@@[A-Z_]+@@') {
     Die "Service template still contains an unresolved placeholder: $($Matches[0])"
 }
 

--- a/scripts/windows/smoke-test.ps1
+++ b/scripts/windows/smoke-test.ps1
@@ -41,11 +41,11 @@ function Get-Status([string]$Path) {
     } catch { return 0 }
 }
 
-Info "Installing Moddex (local mode, port $Port) …"
+Info "Installing Moddex (local mode, port $Port) ..."
 & (Join-Path $ScriptDir 'install.ps1') -Mode local -Port $Port
 
 # Wait for the backend to answer (Spring Boot start can take a while).
-Info 'Waiting for the backend to become reachable …'
+Info 'Waiting for the backend to become reachable ...'
 $reachable = $false
 for ($i = 0; $i -lt 60; $i++) {
     $code = Get-Status '/api/v1/setup/status'
@@ -63,7 +63,7 @@ else { Bad "service not running: $(if ($svc) { $svc.Status } else { 'absent' })"
 # Protected endpoint must reject anonymous access.
 $anon = Get-Status '/api/v1/instance'
 if ($anon -eq 401 -or $anon -eq 403) { Ok "auth enforced (/instance -> $anon without a token)" }
-elseif ($anon -eq 200) { Bad '/instance served WITHOUT a token (200) — auth not enforced' }
+elseif ($anon -eq 200) { Bad '/instance served WITHOUT a token (200) - auth not enforced' }
 else { Info "unexpected anonymous status for /instance: $anon (continuing)" }
 
 Info "Data:   $(Join-Path $env:ProgramData 'Moddex\data')"
@@ -71,7 +71,7 @@ Info "Config: $(Join-Path $env:ProgramData 'Moddex\config')"
 Info "Logs:   $(Join-Path $env:ProgramData 'Moddex\logs')"
 
 if (-not $KeepInstalled) {
-    Info 'Uninstalling (purge) …'
+    Info 'Uninstalling (purge) ...'
     & (Join-Path $ScriptDir 'uninstall.ps1') -Purge
 }
 

--- a/scripts/windows/uninstall.ps1
+++ b/scripts/windows/uninstall.ps1
@@ -36,7 +36,7 @@ if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administra
 }
 
 if (Get-Service -Name $ServiceId -ErrorAction SilentlyContinue) {
-    Write-Log 'Stopping and removing the service …'
+    Write-Log 'Stopping and removing the service ...'
     if (Test-Path $ServiceExe) {
         & $ServiceExe stop      2>$null | Out-Null
         & $ServiceExe uninstall 2>$null | Out-Null


### PR DESCRIPTION
Closes #57

## Der Defekt

`Resolve-Config` fragte `$PSBoundParameters.ContainsKey('Mode')` **innerhalb einer Funktion** ab. Dort beschreibt `$PSBoundParameters` die Parameter *dieser Funktion* — und die Funktion hatte keine. Die Pruefung war also immer `$false`.

Zwei Folgen, die zweite schlimmer als im Ticket beschrieben:

**Bestehende Installation:** ein geerbter Wert gewann immer gegen den expliziten. `-Mode lan` auf einer `local`-Installation aenderte nichts — im Widerspruch zur Doku im Skriptkopf (Zeile 18-19).

**Neuinstallation:** der explizite Port ging vollstaendig verloren.

```powershell
$resolvedPort = $Port          # 9000
if (-not $portExplicit) {      # immer $true
    $existingPort = Get-ExistingEnv 'SERVER_PORT'   # kein Bestand -> $null
    ... else { $resolvedPort = 8080 }               # ueberschreibt die 9000
}
```

`-Port 9000` installierte still auf 8080, auch im nicht-interaktiven Pfad, in dem der Betreiber keine Rueckmeldung sieht.

## Die Aenderung

Explizitheit ist eine Eigenschaft des Skriptaufrufs. Sie wird jetzt **einmal auf Skriptebene** ermittelt und als Parameter durchgereicht:

```powershell
$ModeExplicit = $PSBoundParameters.ContainsKey('Mode')
$PortExplicit = $PSBoundParameters.ContainsKey('Port')
```

`Resolve-WinSw` bekommt dieselbe Behandlung: es las `-WinSwPath` aus dem umgebenden Scope — genau die implizite Kopplung, die diesen Defekt erst moeglich gemacht hat. Zusaetzlich fiel es bei einem nicht existierenden operator-angegebenen Pfad still auf den Download zurueck; das ist jetzt ein Fehler.

Aus demselben Lint-Lauf mitgenommen:

- **Typografische Zeichen durch ASCII ersetzt.** Die Skripte deklarieren `#Requires -Version 5.1`, und Windows PowerShell 5.1 liest UTF-8 ohne BOM als ANSI — die Zeichen kamen beim Betreiber als Zeichensalat an.
- **Platzhalter-Tabelle statt verketteter `.Replace()`**, plus eine Pruefung, die bei einem unaufgeloesten Platzhalter abbricht, statt ihn in die Dienstdefinition zu schreiben, wo er erst als startunwilliger Dienst auffiele.

## Verifikation

PSScriptAnalyzer ueber alle vier Windows-Skripte: **keine Befunde**.

`Resolve-Config` direkt mit PowerShell 7.6.4 ausgefuehrt:

| Fall | Ergebnis | vorher |
|---|---|---|
| Neuinstallation, `-Mode lan -Port 9000` | `lan` / `9000` | `lan` / **8080** |
| Neuinstallation, nur `-Mode lan` | `lan` / `8080` | korrekt |
| Re-Run ohne Argumente (Bestand `local`/`8080`) | `local` / `8080` | korrekt |
| `-Mode lan` gegen Bestand `local` | `lan` / `8080` | **`local`** / `8080` |
| `-Port 9000` gegen Bestand `local`/`8080` | `local` / `9000` | `local` / **8080** |

## Review-Befund

Der Review fand einen **P0-Regress in meiner eigenen Aenderung**: die neue Platzhalter-Pruefung schlug beim echten Template an, weil dessen Kopfkommentar das Wort `@@PLACEHOLDERS@@` zur Erklaerung enthaelt. Jede Windows-Installation waere abgebrochen — bei einem Upgrade sogar erst *nachdem* der laufende Dienst gestoppt wurde. Die Pruefung ignoriert jetzt XML-Kommentare; beide Richtungen sind verifiziert (echtes Template geht durch, echter fehlender Platzhalter wird gefunden).
