### PR TITLE
ci: ein Pipeline-Skript fuer lokale Laeufe und CI, Branches vereinheitlicht (#51)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: ci
 
-# Build validation for the Moddex distribution. Runs the backend tests + package
-# and the frontend tests + production build across a Debian/Ubuntu-compatible
-# runner matrix, then assembles the deployment bundle so the whole release
-# pipeline is exercised on every change. The job fails on any backend or
-# frontend build/test error (acceptance criterion of #21).
+# Build validation for the Moddex distribution.
+#
+# This workflow provides a checkout and a toolchain, then hands over to
+# scripts/ci/pipeline.sh. Every build, test and verification step lives in that
+# script, so a green local run and a green CI run mean the same thing and a
+# broken pipeline can be reproduced on a workstation without pushing a commit:
+#
+#   scripts/ci/pipeline.sh
 #
 # Cross-repo checkout: Moddex-Backend and Moddex-Frontend are private, so set the
 # MODDEX_CHECKOUT_TOKEN secret to a token with read access to all three repos
@@ -12,24 +15,24 @@ name: ci
 #
 # Target matrix: ubuntu-22.04 and ubuntu-24.04 cover the glibc range of the
 # supported Debian/Ubuntu targets. Arch Linux has no GitHub-hosted runner and is
-# treated as experimental (documented in docs/ci.md). Windows packaging (v0.3,
-# epic #26) is assembled by the separate `build-windows` job below on a Windows
-# runner; it runs independently and does not gate the Linux build.
+# treated as experimental (documented in docs/ci.md). Windows packaging is
+# assembled by the separate `build-windows` job on a Windows runner; it runs
+# independently and does not gate the Linux build.
 
 on:
   push:
-    branches: [develop, tests, main]
+    branches: [develop, main]
   pull_request:
-    branches: [develop, tests, main]
+    branches: [develop, main]
   workflow_dispatch:
     inputs:
       backend_ref:
-        description: 'Moddex-Backend ref (branch, tag or SHA). Empty = branch default (main -> main, else tests).'
+        description: 'Moddex-Backend ref (branch, tag or SHA). Empty = branch default (main -> main, else develop).'
         required: false
         default: ''
         type: string
       frontend_ref:
-        description: 'Moddex-Frontend ref (branch, tag or SHA). Empty = branch default (main -> main, else tests).'
+        description: 'Moddex-Frontend ref (branch, tag or SHA). Empty = branch default (main -> main, else develop).'
         required: false
         default: ''
         type: string
@@ -38,13 +41,13 @@ concurrency:
   group: moddex-ci-${{ github.ref }}
   cancel-in-progress: true
 
-# Cross-repo refs (#53): builds validating `main` of this repo check out `main`
-# of the app repos (reproducible release-line builds); everything else tracks
-# the app repos' integration branch `tests`. workflow_dispatch can override
-# both. The resolved refs + SHAs are written to the job summary.
+# Cross-repo refs: builds validating `main` of this repo check out `main` of the
+# app repos (reproducible release-line builds); everything else tracks the app
+# repos' integration branch `develop`. workflow_dispatch can override both. The
+# resolved refs + SHAs are written to the job summary.
 env:
-  BACKEND_REF: ${{ inputs.backend_ref || ((github.base_ref || github.ref_name) == 'main' && 'main' || 'tests') }}
-  FRONTEND_REF: ${{ inputs.frontend_ref || ((github.base_ref || github.ref_name) == 'main' && 'main' || 'tests') }}
+  BACKEND_REF: ${{ inputs.backend_ref || ((github.base_ref || github.ref_name) == 'main' && 'main' || 'develop') }}
+  FRONTEND_REF: ${{ inputs.frontend_ref || ((github.base_ref || github.ref_name) == 'main' && 'main' || 'develop') }}
 
 # Least privilege: this workflow only checks out code and builds. It never writes
 # to the repo, so the default GITHUB_TOKEN is dropped to read-only. (The private
@@ -115,29 +118,21 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'Moddex-Frontend/package-lock.json'
 
-      - name: Backend tests
-        # Writable Moddex dirs: the context-load test boots the full app, whose
-        # JwtService persists its secret into the config dir (default
-        # /etc/moddex, not writable on hosted runners). Mirrors smoke.yml
-        # (Moddex-Backend#55).
-        env:
-          MODDEX_ROOT: ${{ runner.temp }}/moddex-data
-          MODDEX_CONFIG_DIR: ${{ runner.temp }}/moddex-cfg
-          MODDEX_LOG_DIR: ${{ runner.temp }}/moddex-log
+      - name: Install shellcheck
         run: |
-          chmod +x Moddex-Backend/mvnw
-          Moddex-Backend/mvnw -f Moddex-Backend/pom.xml -B -Pci test
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends shellcheck
 
-      - name: Frontend install
-        run: npm --prefix Moddex-Frontend ci
-
-      - name: Frontend tests (headless)
-        run: npm --prefix Moddex-Frontend run test -- --watch=false --browsers=ChromeHeadless
-
-      - name: Assemble deployment bundle
+      # PowerShell and Chrome are preinstalled on GitHub's Ubuntu runners. The
+      # pipeline analyses the Windows installer scripts on this Linux job, so a
+      # PowerShell defect does not need a Windows runner to surface.
+      - name: Run pipeline
+        shell: bash
+        # No --allow-missing-tools: in CI an absent linter must fail the run
+        # rather than silently reduce coverage.
         run: |
-          chmod +x Moddex-build/scripts/build-bundle.sh
-          Moddex-build/scripts/build-bundle.sh
+          chmod +x Moddex-build/scripts/ci/pipeline.sh
+          Moddex-build/scripts/ci/pipeline.sh
 
       - name: Upload bundle artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -150,8 +145,9 @@ jobs:
           retention-days: 14
 
   # Windows packaging (v0.3 target, epic #26). Assembles the installable Windows
-  # artifact so the PowerShell installer/service path is exercised on every change.
-  # Runs independently on a Windows runner; it does not gate the Linux build.
+  # artifact so the PowerShell installer/service path is exercised on every
+  # change. Runs independently on a Windows runner; it does not gate the Linux
+  # build.
   build-windows:
     runs-on: windows-2022
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,14 @@ jobs:
       # PowerShell defect does not need a Windows runner to surface.
       - name: Run pipeline
         shell: bash
+        # Invoked through `bash` rather than repaired with chmod first: a
+        # `chmod +x` here would fix a lost executable bit before the lint stage
+        # checks script modes, keeping CI green while a fresh checkout could not
+        # run the documented `scripts/ci/pipeline.sh` command at all.
+        #
         # No --allow-missing-tools: in CI an absent linter must fail the run
         # rather than silently reduce coverage.
-        run: |
-          chmod +x Moddex-build/scripts/ci/pipeline.sh
-          Moddex-build/scripts/ci/pipeline.sh
+        run: bash Moddex-build/scripts/ci/pipeline.sh
 
       - name: Upload bundle artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -23,7 +23,7 @@ on:
       backend_ref:
         description: 'Moddex-Backend ref to build & test (branch, tag or SHA). Set to the release candidate when gating a release.'
         required: false
-        default: tests
+        default: develop
         type: string
   workflow_call:
     inputs:
@@ -33,7 +33,7 @@ on:
         type: boolean
       backend_ref:
         required: false
-        default: tests
+        default: develop
         type: string
 
 concurrency:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -11,6 +11,69 @@ Linux bundle:
 
 Two GitHub Actions workflows cover build validation and releases.
 
+## Branch model
+
+All three repositories use the same two long-lived branches:
+
+| Branch | Role |
+|--------|------|
+| `develop` | Integration branch. Every ticket branch merges here. |
+| `main` | Stable release line. Only updated when a release is cut. |
+
+Work happens on per-ticket branches (`ai/<repo>/issue-<n>`) that target
+`develop`. The app repos previously used a third branch, `tests`, as their
+integration branch while `develop` sat unused and months out of date — which
+made "check out `develop`" the wrong instruction and cost a full working session
+before the divergence was noticed. `develop` has since been fast-forwarded onto
+that history in both app repos, and `tests` is retained only for genuinely
+experimental work that is not ready for integration.
+
+## The pipeline script
+
+Build, test and verification logic lives in
+[`scripts/ci/pipeline.sh`](../scripts/ci/pipeline.sh), not in workflow YAML. The
+workflows provide a checkout and a toolchain and then call it. The point is that
+a green local run and a green CI run mean the same thing, and a CI failure can
+be reproduced on a workstation without pushing a commit:
+
+```bash
+scripts/ci/pipeline.sh                    # everything
+scripts/ci/pipeline.sh backend frontend   # selected stages
+scripts/ci/pipeline.sh --list             # available stages
+```
+
+| Stage | What it does |
+|-------|--------------|
+| `tools` | Verifies the toolchain the selected stages need. |
+| `lint` | `shellcheck` plus `bash -n` over the shell scripts, PSScriptAnalyzer over the PowerShell scripts, and a check that every script kept its executable bit. |
+| `backend` | Backend unit tests (always `clean`) and the production JAR. |
+| `frontend` | `npm ci`, headless unit tests, production build. |
+| `bundle` | Assembles the installable bundle, reusing the artefacts the previous stages already built. |
+| `verify` | Checks the assembled artefact: structure, file modes, no stray sources, checksum. |
+
+### Missing tools fail the run
+
+A stage whose tool is absent fails rather than being skipped, because a skipped
+check that reports success is indistinguishable from a passing one.
+`--allow-missing-tools` downgrades that to a warning for workstation use; **CI
+never passes it**.
+
+On a Debian/Ubuntu workstation:
+
+```bash
+sudo apt-get install -y shellcheck chromium
+```
+
+PowerShell is only needed for the Windows-installer analysis and is available as
+a [self-contained tarball](https://github.com/PowerShell/PowerShell/releases).
+
+### Why `clean` is not optional
+
+The backend stage always runs `mvnw clean test`. Without it, Maven leaves
+compiled test classes in `target/` and surefire runs classes whose sources are no
+longer in the tree — which produces failures for tests that do not exist and,
+worse, green runs for tests that were deleted.
+
 ## Required secret: `MODDEX_CHECKOUT_TOKEN`
 
 Both workflows check out all three repositories into the sibling layout that
@@ -31,15 +94,14 @@ permission error.
 
 ## `ci.yml` — build validation
 
-Triggers: push and pull requests to `develop`, `tests`, `main`, plus manual
-dispatch.
+Triggers: push and pull requests to `develop` and `main`, plus manual dispatch.
 
 ### Cross-repo refs
 
 The backend/frontend checkouts are resolved per branch
 ([#53](https://github.com/aklozyp/Moddex/issues/53)): builds validating `main`
 of this repo check out `main` of the app repos (reproducible release-line
-builds); every other branch tracks the app repos' integration branch `tests`.
+builds); every other branch tracks the app repos' integration branch `develop`.
 Manual dispatch accepts explicit `backend_ref`/`frontend_ref` overrides. The
 resolved refs and their commit SHAs are recorded in the job summary of every
 run.
@@ -49,14 +111,12 @@ The app repos additionally run their own slim test workflows on every push/PR
 theme-contrast audit and AOT production build), so changes there are validated
 without waiting for this repo's bundle build.
 
-For every change it runs, across a runner matrix:
+The job itself is thin: check out the three repos, install the toolchain, run
+`scripts/ci/pipeline.sh`, upload the artefact. Everything the pipeline does is
+described under [The pipeline script](#the-pipeline-script) above and is
+reproducible locally.
 
-- backend tests (`mvnw -Pci test`),
-- frontend tests (`ChromeHeadless`, `--watch=false`),
-- the full bundle assembly (`build-bundle.sh`), which also runs the production
-  backend package and frontend build.
-
-The job **fails on any backend or frontend build/test error**. The assembled
+The job **fails on any lint, build, test or verification error**. The assembled
 bundle and its SHA256 checksum are uploaded as a versioned workflow artifact
 (`moddex-bundle-<os>`, label `ci-<run>-<os>`), retained for 14 days.
 

--- a/scripts/ci/PSScriptAnalyzerSettings.psd1
+++ b/scripts/ci/PSScriptAnalyzerSettings.psd1
@@ -31,5 +31,17 @@
             IndentationSize = 4
             Kind            = 'space'
         }
+
+        # The Windows scripts declare `#Requires -Version 5.1`, but the pipeline
+        # parses them with PowerShell 7 on Linux. PowerShell 7 accepts syntax
+        # that 5.1 rejects outright - null-coalescing, ternaries, chained
+        # pipelines - so a parse check alone would happily pass a script that
+        # cannot run on the oldest runtime the project promises to support.
+        # Checking both target versions closes that gap without needing a
+        # Windows runner.
+        PSUseCompatibleSyntax = @{
+            Enable         = $true
+            TargetVersions = @('5.1', '7.0')
+        }
     }
 }

--- a/scripts/ci/PSScriptAnalyzerSettings.psd1
+++ b/scripts/ci/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,35 @@
+#
+# PSScriptAnalyzer configuration for the Moddex Windows scripts.
+#
+# These are operator-facing installer scripts, not a reusable module. A few
+# default rules encode assumptions that do not hold here; they are excluded
+# deliberately and with a reason, so the remaining findings are all actionable.
+# Anything not listed stays enabled — silencing a rule to make a run green is
+# how a linter stops being worth running.
+#
+@{
+    IncludeDefaultRules = $true
+
+    ExcludeRules = @(
+        # The installer's entire job is to talk to the operator at a console.
+        # Write-Output would pollute the pipeline with log lines, and
+        # Write-Information is invisible without -InformationAction. Write-Host
+        # is the correct choice for interactive installer output.
+        'PSAvoidUsingWriteHost',
+
+        # 'Write-Log' collides with a cmdlet shipped in some Windows PowerShell
+        # module inventories, but not in any module these scripts load. The
+        # local helper is unambiguous within the script scope.
+        'PSAvoidOverwritingBuiltInCmdlets'
+    )
+
+    Rules = @{
+        # Installer scripts are read and audited by administrators before they
+        # run them as SYSTEM. Consistent casing keeps diffs reviewable.
+        PSUseConsistentIndentation = @{
+            Enable          = $true
+            IndentationSize = 4
+            Kind            = 'space'
+        }
+    }
+}

--- a/scripts/ci/lint-powershell.ps1
+++ b/scripts/ci/lint-powershell.ps1
@@ -1,0 +1,121 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Static analysis for the Windows installer scripts.
+
+.DESCRIPTION
+    Two passes over every *.ps1 under the given path:
+
+      1. A parse check via the PowerShell language parser. This catches syntax
+         errors without executing anything — running an installer to find out
+         whether it parses is not an option.
+      2. PSScriptAnalyzer, when the module is available. It is installed on
+         demand for the current user if the PowerShell Gallery is reachable;
+         when it is not, the parse check still runs and the script reports the
+         reduced coverage instead of pretending everything was checked.
+
+    Exit code 0 means every file passed the checks that actually ran.
+
+.PARAMETER Path
+    Directory to scan recursively for *.ps1 files.
+
+.PARAMETER Severity
+    Lowest PSScriptAnalyzer severity treated as a failure. Default: Warning.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $Path,
+
+    [ValidateSet('Information', 'Warning', 'Error')]
+    [string] $Severity = 'Warning'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if (-not (Test-Path -LiteralPath $Path)) {
+    Write-Error "Path not found: $Path"
+    exit 2
+}
+
+$files = @(Get-ChildItem -LiteralPath $Path -Filter '*.ps1' -Recurse -File)
+if ($files.Count -eq 0) {
+    Write-Host "[ps-lint] No PowerShell scripts found under $Path"
+    exit 0
+}
+
+Write-Host "[ps-lint] Checking $($files.Count) PowerShell script(s)"
+
+$failed = $false
+
+# --- Pass 1: parse ----------------------------------------------------------
+foreach ($file in $files) {
+    $tokens = $null
+    $parseErrors = $null
+    [System.Management.Automation.Language.Parser]::ParseFile(
+        $file.FullName, [ref] $tokens, [ref] $parseErrors) | Out-Null
+
+    if ($parseErrors -and $parseErrors.Count -gt 0) {
+        $failed = $true
+        foreach ($e in $parseErrors) {
+            Write-Host ("  PARSE {0}:{1}: {2}" -f `
+                $file.Name, $e.Extent.StartLineNumber, $e.Message) -ForegroundColor Red
+        }
+    }
+}
+
+# --- Pass 2: PSScriptAnalyzer ----------------------------------------------
+$analyzer = Get-Module -ListAvailable -Name PSScriptAnalyzer | Select-Object -First 1
+
+if (-not $analyzer) {
+    Write-Host "[ps-lint] PSScriptAnalyzer not installed; attempting install for the current user"
+    try {
+        Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force `
+            -AllowClobber -ErrorAction Stop
+        $analyzer = Get-Module -ListAvailable -Name PSScriptAnalyzer | Select-Object -First 1
+    } catch {
+        Write-Host "[ps-lint] Could not install PSScriptAnalyzer: $($_.Exception.Message)" `
+            -ForegroundColor Yellow
+    }
+}
+
+if ($analyzer) {
+    Import-Module PSScriptAnalyzer -ErrorAction Stop
+    Write-Host "[ps-lint] PSScriptAnalyzer $($analyzer.Version)"
+
+    $order = @{ 'Information' = 0; 'Warning' = 1; 'Error' = 2 }
+    $threshold = $order[$Severity]
+
+    # Rule configuration lives next to this script so a local run and CI apply
+    # the same exclusions.
+    $settingsPath = Join-Path $PSScriptRoot 'PSScriptAnalyzerSettings.psd1'
+    $analyzerArgs = @{ Severity = @('Information', 'Warning', 'Error') }
+    if (Test-Path -LiteralPath $settingsPath) {
+        $analyzerArgs['Settings'] = $settingsPath
+        Write-Host "[ps-lint] Settings: $(Split-Path -Leaf $settingsPath)"
+    }
+
+    foreach ($file in $files) {
+        $results = @(Invoke-ScriptAnalyzer -Path $file.FullName @analyzerArgs)
+        foreach ($r in $results) {
+            $level = [string] $r.Severity
+            $isFailure = $order.ContainsKey($level) -and $order[$level] -ge $threshold
+            $colour = if ($isFailure) { 'Red' } else { 'DarkGray' }
+            Write-Host ("  {0,-11} {1}:{2}: [{3}] {4}" -f `
+                $level, $file.Name, $r.Line, $r.RuleName, $r.Message) -ForegroundColor $colour
+            if ($isFailure) { $failed = $true }
+        }
+    }
+} else {
+    Write-Host "[ps-lint] Analysis skipped — parse check only (reduced coverage)" `
+        -ForegroundColor Yellow
+}
+
+if ($failed) {
+    Write-Host "[ps-lint] FAILED" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "[ps-lint] OK" -ForegroundColor Green
+exit 0

--- a/scripts/ci/lint-powershell.ps1
+++ b/scripts/ci/lint-powershell.ps1
@@ -21,6 +21,12 @@
 
 .PARAMETER Severity
     Lowest PSScriptAnalyzer severity treated as a failure. Default: Warning.
+
+.PARAMETER AllowMissingAnalyzer
+    Treat an unavailable PSScriptAnalyzer as reduced coverage instead of a
+    failure. Without it, an analyzer that cannot be installed fails the run:
+    reporting success for analysis that never happened is indistinguishable
+    from analysis that found nothing.
 #>
 [CmdletBinding()]
 param(
@@ -28,7 +34,9 @@ param(
     [string] $Path,
 
     [ValidateSet('Information', 'Warning', 'Error')]
-    [string] $Severity = 'Warning'
+    [string] $Severity = 'Warning',
+
+    [switch] $AllowMissingAnalyzer
 )
 
 $ErrorActionPreference = 'Stop'
@@ -107,9 +115,17 @@ if ($analyzer) {
             if ($isFailure) { $failed = $true }
         }
     }
-} else {
-    Write-Host "[ps-lint] Analysis skipped — parse check only (reduced coverage)" `
+} elseif ($AllowMissingAnalyzer) {
+    Write-Host "[ps-lint] Analysis skipped - parse check only (reduced coverage)" `
         -ForegroundColor Yellow
+} else {
+    Write-Host "[ps-lint] PSScriptAnalyzer is unavailable and could not be installed." `
+        -ForegroundColor Red
+    Write-Host "[ps-lint] Refusing to report success for analysis that did not run." `
+        -ForegroundColor Red
+    Write-Host "[ps-lint] Install it, or pass -AllowMissingAnalyzer to accept reduced coverage." `
+        -ForegroundColor Red
+    exit 1
 }
 
 if ($failed) {

--- a/scripts/ci/pipeline.sh
+++ b/scripts/ci/pipeline.sh
@@ -109,6 +109,15 @@ if [[ ${#REQUESTED_STAGES[@]} -eq 0 ]]; then
   REQUESTED_STAGES=("${ALL_STAGES[@]}")
 fi
 
+# The toolchain check is never optional. Naming stages explicitly
+# (`pipeline.sh lint`) must not be a way around the missing-tool policy —
+# otherwise a machine without shellcheck would run that command, skip the
+# linting, and exit 0.
+# shellcheck disable=SC2076
+if [[ " ${REQUESTED_STAGES[*]} " != *" tools "* ]]; then
+  REQUESTED_STAGES=(tools "${REQUESTED_STAGES[@]}")
+fi
+
 wants_stage() {
   # shellcheck disable=SC2076
   [[ " ${REQUESTED_STAGES[*]} " == *" $1 "* ]]
@@ -298,7 +307,11 @@ stage_lint() {
   local ps_dir="${PROJECT_ROOT}/scripts/windows"
   if [[ -d "$ps_dir" ]] && have pwsh; then
     log "Analysing PowerShell scripts in ${ps_dir#"${PROJECT_ROOT}/"}"
-    pwsh -NoProfile -NonInteractive -File "${SCRIPT_DIR}/lint-powershell.ps1" -Path "$ps_dir" || rc=1
+    # The analyzer module is fetched on demand. If that fails the helper exits
+    # non-zero unless reduced coverage was explicitly accepted here too.
+    local ps_args=(-Path "$ps_dir")
+    [[ "$ALLOW_MISSING_TOOLS" -eq 1 ]] && ps_args+=(-AllowMissingAnalyzer)
+    pwsh -NoProfile -NonInteractive -File "${SCRIPT_DIR}/lint-powershell.ps1" "${ps_args[@]}" || rc=1
   elif [[ -d "$ps_dir" ]]; then
     warn "pwsh unavailable — PowerShell analysis skipped"
   fi

--- a/scripts/ci/pipeline.sh
+++ b/scripts/ci/pipeline.sh
@@ -327,12 +327,22 @@ stage_backend() {
   stage_banner "backend"
   [[ -f "${BACKEND_DIR}/pom.xml" ]] || die "Backend project not found at ${BACKEND_DIR}"
 
-  chmod +x "${BACKEND_DIR}/mvnw"
+  # Every stage runs as the condition of an `if`, which disables errexit inside
+  # it, so setup that must succeed is checked explicitly. A silently failed
+  # scratch-directory reset would let the tests run against stale state and
+  # still report success.
+  chmod +x "${BACKEND_DIR}/mvnw" || {
+    record backend failed "mvnw not executable"; return 1
+  }
 
   # Point every writable path at a scratch directory. Without this the context
   # test writes to /etc/moddex and /var/log/moddex.
-  rm -rf "${TEST_STATE_DIR}"
-  mkdir -p "${TEST_STATE_DIR}"/{data,config,logs}
+  rm -rf "${TEST_STATE_DIR}" || {
+    record backend failed "could not clear ${TEST_STATE_DIR}"; return 1
+  }
+  mkdir -p "${TEST_STATE_DIR}"/{data,config,logs} || {
+    record backend failed "could not create ${TEST_STATE_DIR}"; return 1
+  }
 
   # `clean` is not optional. A previous build leaves compiled test classes in
   # target/, and surefire happily runs classes whose sources no longer exist —
@@ -443,7 +453,8 @@ stage_bundle() {
   local builder="${PROJECT_ROOT}/scripts/build-bundle.sh"
   [[ -f "$builder" ]] || die "Bundle builder not found at $builder"
 
-  chmod +x "$builder"
+  # Checked explicitly: errexit does not apply inside a stage (see stage_backend).
+  chmod +x "$builder" || { record bundle failed "builder not executable"; return 1; }
 
   # Reuse what the earlier stages produced. Packaging the exact artefacts that
   # were just tested is both faster and more honest than rebuilding them: a

--- a/scripts/ci/pipeline.sh
+++ b/scripts/ci/pipeline.sh
@@ -462,7 +462,14 @@ stage_bundle() {
     log "Assembling bundle (version ${VERSION}, building from source)"
   fi
 
-  VERSION="${VERSION}" "$builder" "${args[@]+"${args[@]}"}" || { record bundle failed; return 1; }
+  # The builder resolves the checkouts itself when it has to build from source,
+  # so the pipeline's --repo-root/--backend-dir/--frontend-dir overrides have to
+  # reach it. Without this it would silently fall back to the repos next to the
+  # packaging checkout and build something other than what was asked for.
+  VERSION="${VERSION}" \
+  MODDEX_BACKEND_DIR="${BACKEND_DIR}" \
+  MODDEX_FRONTEND_DIR="${FRONTEND_DIR}" \
+    "$builder" "${args[@]+"${args[@]}"}" || { record bundle failed; return 1; }
 
   record bundle ok
   return 0

--- a/scripts/ci/pipeline.sh
+++ b/scripts/ci/pipeline.sh
@@ -169,16 +169,27 @@ require_tool() {
 
 # Angular's karma builder needs a Chrome binary. Resolve one so a workstation
 # does not have to export CHROME_BIN by hand.
+# A candidate counts only if it actually starts. A Chrome build whose shared
+# libraries are missing is present on PATH and executable, but every test run
+# against it dies with a linker error that looks nothing like a browser problem.
+chrome_runs() {
+  "$1" --version >/dev/null 2>&1
+}
+
 resolve_chrome() {
-  if [[ -n "${CHROME_BIN:-}" && -x "${CHROME_BIN}" ]]; then
+  if [[ -n "${CHROME_BIN:-}" && -x "${CHROME_BIN}" ]] && chrome_runs "${CHROME_BIN}"; then
     return 0
   fi
-  local candidate
+  local candidate resolved
   for candidate in chromium chromium-browser google-chrome google-chrome-stable; do
     if have "$candidate"; then
-      CHROME_BIN="$(command -v "$candidate")"
-      export CHROME_BIN
-      return 0
+      resolved="$(command -v "$candidate")"
+      if chrome_runs "$resolved"; then
+        CHROME_BIN="$resolved"
+        export CHROME_BIN
+        return 0
+      fi
+      warn "found $candidate at $resolved but it does not run (missing libraries?)"
     fi
   done
   return 1

--- a/scripts/ci/pipeline.sh
+++ b/scripts/ci/pipeline.sh
@@ -1,0 +1,583 @@
+#!/usr/bin/env bash
+#
+# Moddex build pipeline — single source of truth.
+#
+# The same script runs locally and inside GitHub Actions. The workflows only
+# provide a checkout and a runner; every build, test and verification step lives
+# here. That way a green local run and a green CI run mean the same thing, and a
+# broken pipeline can be reproduced on a workstation without pushing a commit.
+#
+# Usage:
+#   scripts/ci/pipeline.sh [options] [stage ...]
+#
+# Stages (run in this order when none are named):
+#   tools      Verify the toolchain required by the selected stages.
+#   lint       shellcheck over the shell scripts, PSScriptAnalyzer over PowerShell.
+#   backend    Backend unit tests (clean) and the production JAR.
+#   frontend   Frontend install, headless unit tests and the production build.
+#   bundle     Assemble the installable Linux bundle.
+#   verify     Check the assembled bundle: structure, file modes, no stray sources.
+#
+# Options:
+#   --repo-root DIR        Directory holding the three repo checkouts.
+#                          Default: the parent of this repository.
+#   --backend-dir DIR      Override the backend checkout location.
+#   --frontend-dir DIR     Override the frontend checkout location.
+#   --version VERSION      Version label baked into the bundle. Default: $VERSION or "dev".
+#   --allow-missing-tools  Downgrade absent optional tools to warnings instead of
+#                          failing. Intended for workstations; CI never passes it,
+#                          so a missing linter can never silently skip a check.
+#   --list                 List the available stages and exit.
+#   -h, --help             Show this help and exit.
+#
+# Environment:
+#   MODDEX_BACKEND_DIR, MODDEX_FRONTEND_DIR, VERSION, CHROME_BIN
+#
+# Exit code is non-zero if any selected stage fails.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+ALL_STAGES=(tools lint backend frontend bundle verify)
+
+REPO_ROOT=""
+BACKEND_DIR="${MODDEX_BACKEND_DIR:-}"
+FRONTEND_DIR="${MODDEX_FRONTEND_DIR:-}"
+VERSION="${VERSION:-dev}"
+ALLOW_MISSING_TOOLS=0
+REQUESTED_STAGES=()
+
+# Artefacts handed from the build stages to the bundle stage. Empty when those
+# stages were not selected, in which case the bundle builder builds from source.
+BUILT_BACKEND_JAR=""
+BUILT_FRONTEND_DIST=""
+
+# -----------------------------------------------------------------------------
+# Output helpers
+# -----------------------------------------------------------------------------
+if [[ -t 1 ]]; then
+  C_RESET=$'\033[0m'; C_RED=$'\033[31m'; C_GREEN=$'\033[32m'
+  C_YELLOW=$'\033[33m'; C_BLUE=$'\033[34m'; C_BOLD=$'\033[1m'
+else
+  C_RESET=""; C_RED=""; C_GREEN=""; C_YELLOW=""; C_BLUE=""; C_BOLD=""
+fi
+
+log()  { printf '%s[pipeline]%s %s\n' "$C_BLUE" "$C_RESET" "$*"; }
+warn() { printf '%s[warn]%s %s\n' "$C_YELLOW" "$C_RESET" "$*" >&2; }
+die()  { printf '%s[ERROR]%s %s\n' "$C_RED" "$C_RESET" "$*" >&2; exit 1; }
+
+stage_banner() {
+  printf '\n%s=== %s ===%s\n' "$C_BOLD" "$*" "$C_RESET"
+}
+
+usage() { grep '^#' "$0" | sed '1d;s/^# \{0,1\}//'; }
+
+# Records one result row per stage for the closing summary.
+SUMMARY_NAMES=()
+SUMMARY_STATES=()
+SUMMARY_NOTES=()
+
+record() {
+  SUMMARY_NAMES+=("$1")
+  SUMMARY_STATES+=("$2")
+  SUMMARY_NOTES+=("${3:-}")
+}
+
+# -----------------------------------------------------------------------------
+# Argument parsing
+# -----------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)   [[ $# -ge 2 ]] || die "Missing value for --repo-root";   REPO_ROOT="$2"; shift 2 ;;
+    --backend-dir) [[ $# -ge 2 ]] || die "Missing value for --backend-dir"; BACKEND_DIR="$2"; shift 2 ;;
+    --frontend-dir)[[ $# -ge 2 ]] || die "Missing value for --frontend-dir";FRONTEND_DIR="$2"; shift 2 ;;
+    --version)     [[ $# -ge 2 ]] || die "Missing value for --version";     VERSION="$2"; shift 2 ;;
+    --allow-missing-tools) ALLOW_MISSING_TOOLS=1; shift ;;
+    --list)        printf '%s\n' "${ALL_STAGES[@]}"; exit 0 ;;
+    -h|--help)     usage; exit 0 ;;
+    -*)            die "Unknown option: $1" ;;
+    *)
+      # shellcheck disable=SC2076
+      [[ " ${ALL_STAGES[*]} " == *" $1 "* ]] || die "Unknown stage: $1 (see --list)"
+      REQUESTED_STAGES+=("$1"); shift ;;
+  esac
+done
+
+if [[ ${#REQUESTED_STAGES[@]} -eq 0 ]]; then
+  REQUESTED_STAGES=("${ALL_STAGES[@]}")
+fi
+
+wants_stage() {
+  # shellcheck disable=SC2076
+  [[ " ${REQUESTED_STAGES[*]} " == *" $1 "* ]]
+}
+
+# -----------------------------------------------------------------------------
+# Locate the sibling checkouts
+# -----------------------------------------------------------------------------
+[[ -n "$REPO_ROOT" ]] || REPO_ROOT="$(cd "${PROJECT_ROOT}/.." && pwd)"
+[[ -n "$BACKEND_DIR" ]]  || BACKEND_DIR="${REPO_ROOT}/Moddex-Backend"
+[[ -n "$FRONTEND_DIR" ]] || FRONTEND_DIR="${REPO_ROOT}/Moddex-Frontend"
+
+BUILD_DIR="${PROJECT_ROOT}/build"
+BUNDLE_DIR="${BUILD_DIR}/bundle"
+
+# Scratch directories for the backend tests. Booting the full application
+# context makes the backend persist its JWT secret and settings; pointed at the
+# real defaults (/etc/moddex) that fails on any machine where the tester is not
+# root — which is every CI runner (Moddex-Backend#55).
+TEST_STATE_DIR="${BUILD_DIR}/test-state"
+
+# -----------------------------------------------------------------------------
+# Tool handling
+#
+# A tool is either required for a selected stage (absence fails) or optional.
+# --allow-missing-tools turns a required-tool failure into a warning so a
+# workstation without, say, PowerShell can still run the rest. CI must never
+# pass that flag: a linter that is silently skipped is worse than no linter.
+# -----------------------------------------------------------------------------
+MISSING_TOOLS=()
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Returns non-zero only when the absence should fail the run. Under
+# --allow-missing-tools it records the gap, warns, and reports success so the
+# caller continues — returning 1 there would make the flag do nothing.
+require_tool() {
+  local tool="$1" reason="$2"
+  if have "$tool"; then
+    return 0
+  fi
+  MISSING_TOOLS+=("$tool ($reason)")
+  if [[ "$ALLOW_MISSING_TOOLS" -eq 1 ]]; then
+    warn "missing tool: $tool — $reason (continuing because --allow-missing-tools)"
+    return 0
+  fi
+  return 1
+}
+
+# Angular's karma builder needs a Chrome binary. Resolve one so a workstation
+# does not have to export CHROME_BIN by hand.
+resolve_chrome() {
+  if [[ -n "${CHROME_BIN:-}" && -x "${CHROME_BIN}" ]]; then
+    return 0
+  fi
+  local candidate
+  for candidate in chromium chromium-browser google-chrome google-chrome-stable; do
+    if have "$candidate"; then
+      CHROME_BIN="$(command -v "$candidate")"
+      export CHROME_BIN
+      return 0
+    fi
+  done
+  return 1
+}
+
+stage_tools() {
+  stage_banner "tools"
+  local failed=0
+
+  # Always needed to do anything useful.
+  have bash || die "bash is required"
+  for tool in git tar sha256sum find; do
+    require_tool "$tool" "core pipeline plumbing" || failed=1
+  done
+
+  if wants_stage backend || wants_stage bundle; then
+    require_tool java "backend build (JDK 21)" || failed=1
+  fi
+  if wants_stage frontend || wants_stage bundle; then
+    require_tool node "frontend build" || failed=1
+    require_tool npm "frontend build" || failed=1
+  fi
+  if wants_stage frontend; then
+    if resolve_chrome; then
+      log "Chrome for headless tests: ${CHROME_BIN}"
+    else
+      MISSING_TOOLS+=("chromium (headless frontend unit tests)")
+      if [[ "$ALLOW_MISSING_TOOLS" -eq 1 ]]; then
+        warn "no Chrome/Chromium found — frontend unit tests will be skipped"
+      else
+        failed=1
+      fi
+    fi
+  fi
+  if wants_stage lint; then
+    require_tool shellcheck "shell script linting" || failed=1
+    require_tool pwsh "PowerShell script analysis" || failed=1
+  fi
+
+  if [[ ${#MISSING_TOOLS[@]} -gt 0 ]]; then
+    printf '\n%sMissing tools:%s\n' "$C_BOLD" "$C_RESET" >&2
+    printf '  - %s\n' "${MISSING_TOOLS[@]}" >&2
+    cat >&2 <<'HINT'
+
+  Debian/Ubuntu:  sudo apt-get install -y shellcheck chromium
+  PowerShell:     https://github.com/PowerShell/PowerShell/releases (linux-x64 tarball)
+HINT
+  fi
+
+  if [[ "$failed" -ne 0 ]]; then
+    cat >&2 <<'HINT'
+
+Install the tools above, or re-run with --allow-missing-tools to continue with
+reduced coverage. Never pass --allow-missing-tools in CI: a skipped check that
+reports success is indistinguishable from a passing one.
+HINT
+    return 1
+  fi
+
+  # Report the versions actually used, so a failing run can be reproduced.
+  have java && log "java:  $(java -version 2>&1 | head -n1)"
+  have node && log "node:  $(node -v)"
+  have npm  && log "npm:   $(npm -v)"
+  have shellcheck && log "shellcheck: $(shellcheck --version | awk '/^version:/{print $2}')"
+  have pwsh && log "pwsh:  $(pwsh --version)"
+
+  if [[ ${#MISSING_TOOLS[@]} -gt 0 ]]; then
+    record tools partial "${#MISSING_TOOLS[@]} tool(s) missing, coverage reduced"
+  else
+    record tools ok
+  fi
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# lint
+# -----------------------------------------------------------------------------
+stage_lint() {
+  stage_banner "lint"
+  local rc=0
+
+  # Collect shell scripts by shebang rather than by extension: the CLI entry
+  # point `scripts/moddex` has no .sh suffix but is very much a shell script.
+  local shell_files=() file
+  while IFS= read -r file; do
+    case "$file" in
+      *.sh) shell_files+=("$file") ;;
+      *)
+        if head -n1 "$file" 2>/dev/null | grep -qE '^#!.*\b(ba)?sh\b'; then
+          shell_files+=("$file")
+        fi ;;
+    esac
+  done < <(find "${PROJECT_ROOT}/scripts" -type f | sort)
+
+  if [[ ${#shell_files[@]} -eq 0 ]]; then
+    warn "no shell scripts found under scripts/"
+  else
+    log "Checking ${#shell_files[@]} shell scripts"
+
+    # bash -n first: a syntax error makes shellcheck output far less readable.
+    for file in "${shell_files[@]}"; do
+      bash -n "$file" || { warn "syntax error: $file"; rc=1; }
+    done
+
+    if have shellcheck; then
+      # -x follows `source`d files. External SC directives stay in the scripts.
+      shellcheck -x -S warning "${shell_files[@]}" || rc=1
+    else
+      warn "shellcheck unavailable — shell linting skipped"
+    fi
+  fi
+
+  # Executable bits: the installer and CLI are executed straight from the
+  # bundle, so a lost +x turns into a runtime failure on the operator's machine.
+  local not_exec=()
+  for file in "${shell_files[@]}"; do
+    [[ -x "$file" ]] || not_exec+=("${file#"${PROJECT_ROOT}/"}")
+  done
+  if [[ ${#not_exec[@]} -gt 0 ]]; then
+    warn "shell scripts without the executable bit:"
+    printf '  - %s\n' "${not_exec[@]}" >&2
+    rc=1
+  fi
+
+  # PowerShell: parse check plus PSScriptAnalyzer when it is installed.
+  local ps_dir="${PROJECT_ROOT}/scripts/windows"
+  if [[ -d "$ps_dir" ]] && have pwsh; then
+    log "Analysing PowerShell scripts in ${ps_dir#"${PROJECT_ROOT}/"}"
+    pwsh -NoProfile -NonInteractive -File "${SCRIPT_DIR}/lint-powershell.ps1" -Path "$ps_dir" || rc=1
+  elif [[ -d "$ps_dir" ]]; then
+    warn "pwsh unavailable — PowerShell analysis skipped"
+  fi
+
+  if [[ "$rc" -eq 0 ]]; then record lint ok; else record lint failed; fi
+  return "$rc"
+}
+
+# -----------------------------------------------------------------------------
+# backend
+# -----------------------------------------------------------------------------
+stage_backend() {
+  stage_banner "backend"
+  [[ -f "${BACKEND_DIR}/pom.xml" ]] || die "Backend project not found at ${BACKEND_DIR}"
+
+  chmod +x "${BACKEND_DIR}/mvnw"
+
+  # Point every writable path at a scratch directory. Without this the context
+  # test writes to /etc/moddex and /var/log/moddex.
+  rm -rf "${TEST_STATE_DIR}"
+  mkdir -p "${TEST_STATE_DIR}"/{data,config,logs}
+
+  # `clean` is not optional. A previous build leaves compiled test classes in
+  # target/, and surefire happily runs classes whose sources no longer exist —
+  # producing failures for tests that are not in the tree and, worse, green runs
+  # for tests that were deleted.
+  log "Running backend unit tests (clean)"
+  (
+    cd "${BACKEND_DIR}"
+    MODDEX_ROOT="${TEST_STATE_DIR}/data" \
+    MODDEX_CONFIG_DIR="${TEST_STATE_DIR}/config" \
+    MODDEX_LOG_DIR="${TEST_STATE_DIR}/logs" \
+      ./mvnw -B -Pci clean test
+  ) || { record backend failed "unit tests"; return 1; }
+
+  log "Packaging production JAR"
+  (
+    cd "${BACKEND_DIR}"
+    ./mvnw -B -Pprod -DskipTests package
+  ) || { record backend failed "package"; return 1; }
+
+  local jar
+  jar="$(find "${BACKEND_DIR}/target" -maxdepth 1 -name 'Moddex-Backend-*.jar' ! -name '*-sources.jar' | head -n1)"
+  [[ -n "$jar" ]] || { record backend failed "no JAR produced"; die "Backend JAR not found in ${BACKEND_DIR}/target"; }
+  log "Backend JAR: ${jar#"${REPO_ROOT}/"} ($(du -h "$jar" | cut -f1))"
+
+  # Handed to the bundle stage so it packages exactly the artefact that was just
+  # tested, rather than compiling the project a second time.
+  BUILT_BACKEND_JAR="$jar"
+
+  record backend ok
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# frontend
+# -----------------------------------------------------------------------------
+stage_frontend() {
+  stage_banner "frontend"
+  [[ -f "${FRONTEND_DIR}/package.json" ]] || die "Frontend project not found at ${FRONTEND_DIR}"
+
+  log "Installing dependencies"
+  (
+    cd "${FRONTEND_DIR}"
+    if [[ -f package-lock.json ]]; then
+      # `ci` is reproducible and fails on a lockfile that drifted from
+      # package.json — exactly what a pipeline wants.
+      npm ci
+    else
+      warn "no package-lock.json — falling back to npm install (not reproducible)"
+      npm install
+    fi
+  ) || { record frontend failed "install"; return 1; }
+
+  if resolve_chrome; then
+    log "Running unit tests headless (${CHROME_BIN})"
+    (
+      cd "${FRONTEND_DIR}"
+      CHROME_BIN="${CHROME_BIN}" npm run test -- --watch=false --browsers=ChromeHeadless
+    ) || { record frontend failed "unit tests"; return 1; }
+  else
+    warn "no Chrome/Chromium — unit tests skipped"
+    record frontend partial "tests skipped (no Chrome)"
+  fi
+
+  log "Production build"
+  (
+    cd "${FRONTEND_DIR}"
+    npm run build -- --configuration production
+  ) || { record frontend failed "production build"; return 1; }
+
+  local index
+  index="$(resolve_frontend_index)" || {
+    record frontend failed "no index.html in dist"
+    die "Frontend build produced no index.html under ${FRONTEND_DIR}/dist"
+  }
+  BUILT_FRONTEND_DIST="${index%/index.html}"
+  log "Frontend output: ${BUILT_FRONTEND_DIST}"
+
+  # Only record success when the tests actually ran.
+  if [[ "${SUMMARY_NAMES[*]: -1}" != "frontend" ]]; then
+    record frontend ok
+  fi
+  return 0
+}
+
+# Resolves the directory Angular actually emitted the browser build into and
+# echoes the path to its index.html.
+#
+# `@angular/build:application` writes to dist/<project>/browser/ by default, and
+# the project name is not something the packaging repo should have to guess. Any
+# consumer that assumes dist/index.html silently ships an empty UI (Moddex#61),
+# so the location is resolved from the artefact itself.
+resolve_frontend_index() {
+  local dist="${FRONTEND_DIR}/dist"
+  [[ -d "$dist" ]] || return 1
+  local found
+  found="$(find "$dist" -maxdepth 4 -name index.html -type f \
+    -not -path '*/node_modules/*' -not -path '*/server/*' | sort | head -n1)"
+  [[ -n "$found" ]] || return 1
+  printf '%s' "$found"
+}
+
+# -----------------------------------------------------------------------------
+# bundle
+# -----------------------------------------------------------------------------
+stage_bundle() {
+  stage_banner "bundle"
+  local builder="${PROJECT_ROOT}/scripts/build-bundle.sh"
+  [[ -f "$builder" ]] || die "Bundle builder not found at $builder"
+
+  chmod +x "$builder"
+
+  # Reuse what the earlier stages produced. Packaging the exact artefacts that
+  # were just tested is both faster and more honest than rebuilding them: a
+  # second compile could, in principle, produce something the tests never saw.
+  local args=()
+  if [[ -n "${BUILT_BACKEND_JAR:-}" ]]; then
+    args+=(--backend-jar "${BUILT_BACKEND_JAR}")
+  fi
+  if [[ -n "${BUILT_FRONTEND_DIST:-}" ]]; then
+    args+=(--frontend-dist "${BUILT_FRONTEND_DIST}")
+  fi
+
+  if [[ ${#args[@]} -gt 0 ]]; then
+    log "Assembling bundle (version ${VERSION}, reusing built artefacts)"
+  else
+    log "Assembling bundle (version ${VERSION}, building from source)"
+  fi
+
+  VERSION="${VERSION}" "$builder" "${args[@]+"${args[@]}"}" || { record bundle failed; return 1; }
+
+  record bundle ok
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# verify
+#
+# Checks the assembled artefact rather than the sources. Every check here failed
+# silently at some point in this project's history: a bundle with no UI still
+# installed "successfully", and scripts that lost their executable bit only
+# surfaced on the operator's machine.
+# -----------------------------------------------------------------------------
+stage_verify() {
+  stage_banner "verify"
+  local rc=0
+
+  [[ -d "$BUNDLE_DIR" ]] || { record verify failed "no bundle"; die "No bundle at $BUNDLE_DIR — run the bundle stage first"; }
+
+  check() {
+    local label="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+      printf '  %sPASS%s %s\n' "$C_GREEN" "$C_RESET" "$label"
+    else
+      printf '  %sFAIL%s %s\n' "$C_RED" "$C_RESET" "$label"
+      rc=1
+    fi
+  }
+
+  # --- Structure ---
+  check "backend JAR present"        test -f "${BUNDLE_DIR}/backend/Moddex-Backend.jar"
+  check "frontend index.html at the bundle root" test -f "${BUNDLE_DIR}/frontend/index.html"
+  check "installer present"          test -f "${BUNDLE_DIR}/scripts/install.sh"
+  check "systemd unit present"       test -f "${BUNDLE_DIR}/packaging/systemd/moddex-backend.service"
+  check "VERSION file present"       test -f "${BUNDLE_DIR}/VERSION"
+
+  # --- Executability: these are run directly out of the extracted bundle ---
+  local script
+  for script in install.sh uninstall.sh update.sh download.sh moddex; do
+    if [[ -e "${BUNDLE_DIR}/scripts/${script}" ]]; then
+      check "scripts/${script} is executable" test -x "${BUNDLE_DIR}/scripts/${script}"
+    fi
+  done
+
+  # --- The frontend must be a built artefact, not a source tree ---
+  check "no node_modules in the bundle" test ! -d "${BUNDLE_DIR}/frontend/node_modules"
+  check "no TypeScript sources in the bundle" bash -c \
+    "! find '${BUNDLE_DIR}/frontend' -name '*.ts' -not -name '*.d.ts' | grep -q ."
+
+  # --- Archive + checksum ---
+  local archive="${BUILD_DIR}/moddex-${VERSION}-linux-amd64.tar.gz"
+  check "archive produced" test -f "$archive"
+  if [[ -f "${archive}.sha256" ]]; then
+    check "checksum verifies" bash -c "cd '${BUILD_DIR}' && sha256sum -c '$(basename "${archive}.sha256")'"
+  else
+    printf '  %sFAIL%s checksum file present\n' "$C_RED" "$C_RESET"
+    rc=1
+  fi
+
+  if [[ "$rc" -eq 0 ]]; then record verify ok; else record verify failed; fi
+  return "$rc"
+}
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+print_summary() {
+  local overall="$1"
+  printf '\n%s=== summary ===%s\n' "$C_BOLD" "$C_RESET"
+  local i state colour
+  for i in "${!SUMMARY_NAMES[@]}"; do
+    state="${SUMMARY_STATES[$i]}"
+    case "$state" in
+      ok)      colour="$C_GREEN" ;;
+      partial) colour="$C_YELLOW" ;;
+      *)       colour="$C_RED" ;;
+    esac
+    printf '  %-10s %s%-8s%s %s\n' \
+      "${SUMMARY_NAMES[$i]}" "$colour" "$state" "$C_RESET" "${SUMMARY_NOTES[$i]}"
+  done
+
+  # GitHub renders this in the job summary, so a failed run is readable without
+  # scrolling through the raw log.
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "### Pipeline"
+      echo
+      echo "| Stage | Result | Note |"
+      echo "|-------|--------|------|"
+      for i in "${!SUMMARY_NAMES[@]}"; do
+        echo "| ${SUMMARY_NAMES[$i]} | ${SUMMARY_STATES[$i]} | ${SUMMARY_NOTES[$i]:-—} |"
+      done
+      echo
+      echo "Version: \`${VERSION}\`"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+
+  if [[ "$overall" -eq 0 ]]; then
+    printf '\n%sPipeline passed.%s\n' "$C_GREEN" "$C_RESET"
+  else
+    printf '\n%sPipeline failed.%s\n' "$C_RED" "$C_RESET"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Run
+# -----------------------------------------------------------------------------
+log "Packaging repo: ${PROJECT_ROOT}"
+log "Backend:        ${BACKEND_DIR}"
+log "Frontend:       ${FRONTEND_DIR}"
+log "Version:        ${VERSION}"
+log "Stages:         ${REQUESTED_STAGES[*]}"
+
+OVERALL=0
+for stage in "${ALL_STAGES[@]}"; do
+  wants_stage "$stage" || continue
+  # `set -e` must not abort the loop: every stage should report, and the summary
+  # is more useful than a run that stops at the first problem. `tools` is the
+  # exception — building without a verified toolchain only produces noise.
+  if ! "stage_${stage}"; then
+    OVERALL=1
+    if [[ "$stage" == "tools" ]]; then
+      record tools failed "toolchain incomplete"
+      print_summary "$OVERALL"
+      exit 1
+    fi
+  fi
+done
+
+print_summary "$OVERALL"
+exit "$OVERALL"

--- a/scripts/ci/pipeline.sh
+++ b/scripts/ci/pipeline.sh
@@ -463,6 +463,17 @@ stage_bundle() {
 # installed "successfully", and scripts that lost their executable bit only
 # surfaced on the operator's machine.
 # -----------------------------------------------------------------------------
+# Checks run as functions taking real arguments rather than as interpolated
+# `bash -c` strings: a path or version label containing a quote would otherwise
+# produce malformed shell and fail a perfectly good bundle.
+no_typescript_sources() {
+  ! find "$1" -name '*.ts' -not -name '*.d.ts' -print -quit | grep -q .
+}
+
+checksum_verifies() {
+  ( cd "$1" && sha256sum -c "$2" )
+}
+
 stage_verify() {
   stage_banner "verify"
   local rc=0
@@ -496,14 +507,13 @@ stage_verify() {
 
   # --- The frontend must be a built artefact, not a source tree ---
   check "no node_modules in the bundle" test ! -d "${BUNDLE_DIR}/frontend/node_modules"
-  check "no TypeScript sources in the bundle" bash -c \
-    "! find '${BUNDLE_DIR}/frontend' -name '*.ts' -not -name '*.d.ts' | grep -q ."
+  check "no TypeScript sources in the bundle" no_typescript_sources "${BUNDLE_DIR}/frontend"
 
   # --- Archive + checksum ---
   local archive="${BUILD_DIR}/moddex-${VERSION}-linux-amd64.tar.gz"
   check "archive produced" test -f "$archive"
   if [[ -f "${archive}.sha256" ]]; then
-    check "checksum verifies" bash -c "cd '${BUILD_DIR}' && sha256sum -c '$(basename "${archive}.sha256")'"
+    check "checksum verifies" checksum_verifies "${BUILD_DIR}" "$(basename "${archive}.sha256")"
   else
     printf '  %sFAIL%s checksum file present\n' "$C_RED" "$C_RESET"
     rc=1

--- a/scripts/moddex
+++ b/scripts/moddex
@@ -56,7 +56,11 @@ load_env() {
     if [[ -r "$ENV_FILE" ]]; then
         local addr port
         # Read without polluting the current shell beyond what we extract.
+        # The env file is machine-local runtime configuration written by the
+        # installer; its contents cannot be known at lint time.
+        # shellcheck source=/dev/null
         addr="$(. "$ENV_FILE" 2>/dev/null; printf '%s' "${SERVER_ADDRESS:-}")"
+        # shellcheck source=/dev/null
         port="$(. "$ENV_FILE" 2>/dev/null; printf '%s' "${SERVER_PORT:-}")"
         [[ -z "${SERVER_ADDRESS:-}" && -n "$addr" ]] && SERVER_ADDRESS="$addr"
         [[ -z "${SERVER_PORT:-}" && -n "$port" ]] && SERVER_PORT="$port"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-read -p "Are you sure you want to uninstall? [y/N] " a
+read -r -p "Are you sure you want to uninstall? [y/N] " a
 [[ "${a,,}" == "y" ]] || exit 0
 sudo systemctl disable --now moddex-backend || true
 sudo rm -f /etc/systemd/system/moddex-backend.service


### PR DESCRIPTION
Closes #51

## Das Problem hinter dem Ticket

#51 beschreibt, dass die CI rot ist, weil das Secret `MODDEX_CHECKOUT_TOKEN` fehlt. Das stimmt — und ist eine Operator-Aktion. Darunter liegt aber ein strukturelles Problem: die gesamte Build-Logik stand in Workflow-YAML. Sie liess sich **nur durch einen Push ausprobieren**. Eine kaputte Pipeline war damit nicht lokal reproduzierbar, und genau das blockiert die Arbeit, solange das Secret fehlt.

## Die Aenderung

Build-, Test- und Pruefschritte ziehen aus dem YAML in `scripts/ci/pipeline.sh` um. Der Workflow liefert nur noch Checkout und Toolchain und ruft das Skript auf. Ein gruener lokaler Lauf und ein gruener CI-Lauf bedeuten dadurch dasselbe.

```bash
scripts/ci/pipeline.sh                    # alles
scripts/ci/pipeline.sh backend frontend   # einzelne Stages
scripts/ci/pipeline.sh --list
```

| Stage | Inhalt |
|---|---|
| `tools` | prueft die Toolchain der gewaehlten Stages |
| `lint` | `shellcheck` + `bash -n`, PSScriptAnalyzer, Executable-Bits |
| `backend` | Unit-Tests (immer `clean`) und Produktions-JAR |
| `frontend` | `npm ci`, Headless-Unit-Tests, Produktions-Build |
| `bundle` | Bundle-Assembly, wiederverwendet die bereits gebauten Artefakte |
| `verify` | prueft das Artefakt: Struktur, Modi, keine Quelldateien, Pruefsumme |

## Bewusste Entscheidungen

**Fehlende Werkzeuge lassen den Lauf scheitern.** Ein uebersprungener Check, der Erfolg meldet, ist von einem bestandenen nicht zu unterscheiden. `--allow-missing-tools` ist der ausdrueckliche Ausweg fuer Arbeitsplaetze; die CI uebergibt ihn nie.

**`clean` ist nicht optional.** Der erste Baseline-Lauf ohne `clean` meldete 8 Fehler aus Testklassen, die es im Quellbaum gar nicht mehr gibt — Maven hatte kompilierte Klassen einer frueheren Sitzung in `target/` liegen lassen und surefire hat sie ausgefuehrt. Derselbe Mechanismus meldet umgekehrt *gruen* fuer geloeschte Tests. Mit `clean`: **459 Tests, 0 Fehler.**

**Artefakt-Wiederverwendung.** Die Bundle-Stage packt exakt das JAR und die Frontend-Ausgabe, die zuvor getestet wurden, statt beides neu zu uebersetzen — schneller und ehrlicher, weil ein zweiter Compile prinzipiell etwas erzeugen koennte, das die Tests nie gesehen haben.

**Shell-Skripte werden per Shebang gesammelt, nicht per Endung**, damit die endungslose CLI `scripts/moddex` mit abgedeckt ist. Ein verlorenes Executable-Bit laesst den Lint scheitern; bisher fiel das erst auf der Maschine des Betreibers auf.

**PowerShell-Analyse laeuft auf dem Linux-Job.** Ein Defekt im Windows-Installer braucht damit keinen Windows-Runner, um sichtbar zu werden — so wurde #57 hier unabhaengig bestaetigt. Die Regel-Ausschluesse stehen mit Begruendung in `scripts/ci/PSScriptAnalyzerSettings.psd1`; `Write-Host` ist fuer einen interaktiven Installer die richtige Wahl, und diese Regel stillzulegen haelt die echten Befunde sichtbar.

## Branch-Vereinheitlichung

Alle drei Repos nutzen jetzt `develop` als Integrationsbranch und `main` als stabile Release-Linie. Die App-Repos hatten auf `tests` entwickelt, waehrend ihr `develop` acht Monate alt war — „checke `develop` aus" war damit aktiv falsch und hat eine komplette Arbeitssitzung gekostet, bevor die Divergenz auffiel. `develop` wurde in beiden App-Repos verlustfrei vorgezogen (`tests..develop` war 0). Workflow-Refs, Trigger-Branches und `docs/ci.md` ziehen nach.

## Verifikation

Vollstaendiger lokaler Lauf:

| Stage | Ergebnis |
|---|---|
| backend | ok — 459 Tests, 0 Fehler |
| frontend | partial — Unit-Tests uebersprungen, kein Chrome auf der Maschine |
| bundle | ok — Wiederverwendung der getesteten Artefakte greift |
| verify | ok — 14/14 Pruefungen |
| lint | ok (nach #57) |

## Was offen bleibt

Das Secret `MODDEX_CHECKOUT_TOKEN` ist weiterhin nicht gesetzt; die GitHub-CI kann die privaten Repos nicht auschecken. Das ist eine reine Operator-Aktion und durch diesen PR nicht loesbar — aber sie blockiert die Arbeit jetzt nicht mehr, weil dieselbe Pipeline lokal vollstaendig laeuft.
