### PR TITLE
feat(install): UI dorthin ausliefern, wo das Backend sie erwartet (#59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ Verzeichnisstruktur nach der Installation:
 | Pfad | Berechtigungen | Inhalt |
 |------|---------------|--------|
 | `/opt/moddex/` | `0755 moddex:moddex` | Anwendungsdateien (`app.jar`, `VERSION`) |
+| `/opt/moddex/ui/` | `0755 root:root` | Gebaute Web-UI, vom Backend ausgeliefert; fuer den Dienst nur lesbar |
 | `/var/lib/moddex/` | `0755 moddex:moddex` | Laufzeitdaten (Datenbank, Instanz- und Backup-Daten) |
-| `/var/lib/moddex/ui/` | `0755 moddex:moddex` | Statische Frontend-Assets |
 | `/var/log/moddex/` | `0755 moddex:moddex` | Backend-Logs (`backend.out.log`, `backend.err.log`) |
 | `/etc/moddex/` | `0750 root:moddex` | Maschinen-lokale Konfiguration |
 | `/etc/moddex/moddex.env` | `0640 root:moddex` | Betriebsmodus, Bind-Adresse, Port (vom Installer geschrieben) |
@@ -322,10 +322,9 @@ server {
         proxy_set_header   Forwarded "";
     }
 
-    # Statische Frontend-Assets direkt ausliefern (optional, performanter)
-    # location /assets/ {
-    #     root /var/lib/moddex/ui;
-    # }
+    # Ein separater Webserver fuer das Frontend ist nicht noetig: das Backend
+    # liefert die UI auf demselben Port wie die API aus (Moddex#59). Der Proxy
+    # oben reicht sowohl die Oberflaeche als auch die API durch.
 }
 
 server {

--- a/packaging/systemd/moddex-backend.service
+++ b/packaging/systemd/moddex-backend.service
@@ -18,6 +18,9 @@ EnvironmentFile=-/etc/moddex/moddex.env
 Environment=MODDEX_ROOT=/var/lib/moddex
 Environment=MODDEX_CONFIG_DIR=/etc/moddex
 Environment=MODDEX_LOG_DIR=/var/log/moddex
+# Built web UI, served by the backend on the same port as the API (Moddex#59).
+# Deliberately outside ReadWritePaths below: the service only reads it.
+Environment=MODDEX_UI_DIR=/opt/moddex/ui
 Environment=SERVER_ADDRESS=127.0.0.1
 Environment=SERVER_PORT=8080
 

--- a/packaging/windows/moddex-backend.xml.template
+++ b/packaging/windows/moddex-backend.xml.template
@@ -27,6 +27,10 @@
   <env name="MODDEX_ROOT" value="@@DATA_DIR@@" />
   <env name="MODDEX_CONFIG_DIR" value="@@CONFIG_DIR@@" />
   <env name="MODDEX_LOG_DIR" value="@@LOG_DIR@@" />
+  <!-- Built web UI, served by the backend on the same port as the API
+       (Moddex#59). Without this the backend falls back to its Linux default
+       (/opt/moddex/ui) and a Windows install serves no browser interface. -->
+  <env name="MODDEX_UI_DIR" value="@@UI_DIR@@" />
   <env name="MODDEX_MODE" value="@@MODE@@" />
   <!-- Drives the backend's CORS/security policy (moddex.security.mode); must match
        MODDEX_MODE so a lan/public install does not run with the local default. -->

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -391,7 +391,15 @@ fi
 
 log "Reloading systemd and starting backend"
 systemctl daemon-reload
-systemctl enable --now moddex-backend.service
+systemctl enable moddex-backend.service
+# `enable --now` starts a stopped unit but does not restart a running one, so an
+# upgrade would leave the old JVM serving the old JAR and the old environment.
+# That is bad enough on its own; combined with the UI migration above it is
+# worse, because the previous UI directory is already gone while the running
+# process does not know about the new one. An explicit restart is the only thing
+# that makes an upgrade take effect. (Staging, readiness and rollback around
+# this are tracked in #62.)
+systemctl restart moddex-backend.service
 
 if [[ "$MODE" != "local" ]]; then
   if command -v ufw >/dev/null 2>&1; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,6 +28,7 @@ SYSTEMD_DIR="$PROJECT_ROOT/packaging/systemd"
 # Filesystem layout (FHS-aligned). The backend reads these via MODDEX_* env vars
 # (see application.yml), so the installer, systemd unit and CLI all agree.
 APP_DIR=/opt/moddex
+UI_DIR=/opt/moddex/ui
 DATA_DIR=/var/lib/moddex
 CONFIG_DIR=/etc/moddex
 LOG_DIR=/var/log/moddex
@@ -243,8 +244,12 @@ fi
 
 install -d -m 0755 -o moddex -g moddex "$APP_DIR"
 install -d -m 0755 -o moddex -g moddex "$DATA_DIR"
-install -d -m 0755 -o moddex -g moddex "$DATA_DIR/ui"
 install -d -m 0755 -o moddex -g moddex "$LOG_DIR"
+# The web UI belongs to the application, not to the instance data: it is
+# replaced wholesale on every upgrade and the service must never be able to
+# rewrite what browsers are served. Hence root-owned under /opt and only
+# readable by the service (Moddex#59).
+install -d -m 0755 -o root -g root "$UI_DIR"
 # Config is root-owned but group-readable by the service so secrets in moddex.env
 # are not world-readable.
 install -d -m 0750 -o root -g moddex "$CONFIG_DIR"
@@ -271,14 +276,23 @@ chown moddex:moddex "$APP_DIR/VERSION"
 log "Installed version: $VERSION_STRING"
 
 if [[ -n "$FRONTEND_DIR" ]]; then
-  log "Deploying frontend assets from $FRONTEND_DIR"
-  rsync -a --delete --chown=moddex:moddex "$FRONTEND_DIR/" "$DATA_DIR/ui/"
-elif [[ -n "$(ls -A "$DATA_DIR/ui" 2>/dev/null)" ]]; then
+  log "Deploying frontend assets to $UI_DIR"
+  rsync -a --delete --chown=root:root "$FRONTEND_DIR/" "$UI_DIR/"
+  find "$UI_DIR" -type d -exec chmod 0755 {} +
+  find "$UI_DIR" -type f -exec chmod 0644 {} +
+elif [[ -n "$(ls -A "$UI_DIR" 2>/dev/null)" ]]; then
   # A backend-only re-install over an existing installation must not leave the
-  # previous UI in place: anything still serving that directory would hand out
-  # an old frontend against a newer backend.
-  log "Removing the previously installed web UI from $DATA_DIR/ui (--without-frontend)"
-  find "$DATA_DIR/ui" -mindepth 1 -delete
+  # previous UI in place: the backend would keep serving an old frontend against
+  # a newer API.
+  log "Removing the previously installed web UI from $UI_DIR (--without-frontend)"
+  find "$UI_DIR" -mindepth 1 -delete
+fi
+
+# One-time migration: earlier installs put the UI in the instance data
+# directory, where nothing served it and the service could write to it.
+if [[ -d "$DATA_DIR/ui" ]]; then
+  log "Removing the obsolete UI directory at $DATA_DIR/ui (now served from $UI_DIR)"
+  rm -rf "$DATA_DIR/ui"
 fi
 
 case "$MODE" in
@@ -303,6 +317,7 @@ MODDEX_SECURITY_MODE=$MODE
 MODDEX_ROOT=$DATA_DIR
 MODDEX_CONFIG_DIR=$CONFIG_DIR
 MODDEX_LOG_DIR=$LOG_DIR
+MODDEX_UI_DIR=$UI_DIR
 SERVER_ADDRESS=$SERVER_ADDRESS
 SERVER_PORT=$SERVER_PORT
 # Transport security (Moddex-Backend#50). Behind a TLS-terminating reverse
@@ -390,10 +405,12 @@ if [[ "$MODE" != "local" ]]; then
 fi
 
 log "Installation complete"
+# The backend serves the web UI on the same port as the API (Moddex#59), so
+# there is one address to hand the operator, not two.
 case "$MODE" in
-  local) printf 'Backend API reachable at: http://127.0.0.1:%s\n' "$SERVER_PORT" ;;
-  lan)   printf 'Backend API reachable at: http://<server-ip>:%s\n' "$SERVER_PORT" ;;
-  public) printf 'Backend API reachable at: http://<public-host>:%s (no TLS configured)\n' "$SERVER_PORT" ;;
+  local) printf 'Web UI and API: http://127.0.0.1:%s\n' "$SERVER_PORT" ;;
+  lan)   printf 'Web UI and API: http://<server-ip>:%s\n' "$SERVER_PORT" ;;
+  public) printf 'Web UI and API: http://<public-host>:%s (no TLS configured)\n' "$SERVER_PORT" ;;
 esac
 printf 'Systemd unit: moddex-backend.service\n'
 printf 'Configuration: %s\n' "$ENV_FILE"
@@ -402,7 +419,9 @@ if command -v moddex >/dev/null 2>&1 || [[ -x "$CLI_PATH" ]]; then
   printf 'CLI installed: run "moddex status" or "moddex help".\n'
 fi
 if [[ -n "$FRONTEND_DIR" ]]; then
-  printf 'Static frontend copied to %s/ui (serve separately).\n' "$DATA_DIR"
+  printf 'Web UI served from: %s (no separate web server needed)\n' "$UI_DIR"
+else
+  printf 'Installed without a web UI (--without-frontend); the API is available, the browser interface is not.\n'
 fi
 printf 'Complete the first-run setup in the web UI to set an admin password. Then verify a protected endpoint returns 401 without a token, e.g.:\n'
 printf '  curl -i http://127.0.0.1:%s/api/v1/instance\n' "$SERVER_PORT"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -8,7 +8,7 @@
 #
 # Usage:
 #   BASE_URL=http://127.0.0.1:8080 TOKEN=<jwt> INSTANCE_ID=<uuid> \
-#     scripts/smoke-test.sh [--with-restore]
+#     scripts/smoke-test.sh [--with-restore] [--without-frontend]
 #
 # Environment:
 #   BASE_URL      Backend base URL (default: http://127.0.0.1:8080)
@@ -18,6 +18,13 @@
 # Flags:
 #   --with-restore   Also run the (destructive) restore step. Restore overwrites
 #                    the current instance state, so it is opt-in only.
+#   --without-frontend
+#                    Skip the web UI checks. Matches install.sh's flag of the
+#                    same name: a backend-only installation is a supported
+#                    configuration, and this script must be usable against one.
+#                    The checks are never skipped automatically - a missing UI
+#                    is exactly the defect they exist to catch, so opting out
+#                    has to be a statement of intent.
 #
 # Exit code is non-zero if any checked step fails.
 
@@ -27,10 +34,12 @@ BASE_URL="${BASE_URL:-http://127.0.0.1:8080}"
 TOKEN="${TOKEN:-}"
 INSTANCE_ID="${INSTANCE_ID:-}"
 WITH_RESTORE=0
+WITHOUT_FRONTEND=0
 
 for arg in "$@"; do
   case "$arg" in
     --with-restore) WITH_RESTORE=1 ;;
+    --without-frontend) WITHOUT_FRONTEND=1 ;;
     -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *) echo "Unknown argument: $arg" >&2; exit 2 ;;
   esac
@@ -86,41 +95,45 @@ fi
 # The backend serves the built UI on this same port. Before that existed, an
 # installation could pass every API check here and still have no usable browser
 # interface, so these checks exist to make that state impossible to miss.
-ui_body="$(curl -s "${BASE_URL}/" || true)"
-ui_code=$(http_status GET /)
-ui_type=$(curl -s -o /dev/null -w '%{content_type}' "${BASE_URL}/" || true)
-
-if [[ "$ui_code" == "200" && "$ui_type" == text/html* ]]; then
-  ok "web UI served at / (200 $ui_type)"
-elif [[ "$ui_code" == "404" ]]; then
-  bad "no web UI at / (404) — the bundle installed no frontend, or nothing serves it"
+if [[ "$WITHOUT_FRONTEND" -eq 1 ]]; then
+  log "Skipping web UI checks (--without-frontend)."
 else
-  bad "unexpected response for / ($ui_code $ui_type)"
-fi
+  ui_body="$(curl -s "${BASE_URL}/" || true)"
+  ui_code=$(http_status GET /)
+  ui_type=$(curl -s -o /dev/null -w '%{content_type}' "${BASE_URL}/" || true)
 
-if [[ -n "$ui_body" ]] && printf '%s' "$ui_body" | grep -qi '<app-root'; then
-  ok "app shell present in the served document"
-else
-  bad "document at / does not contain the Angular app shell"
-fi
+  if [[ "$ui_code" == "200" && "$ui_type" == text/html* ]]; then
+    ok "web UI served at / (200 $ui_type)"
+  elif [[ "$ui_code" == "404" ]]; then
+    bad "no web UI at / (404) — the bundle installed no frontend, or nothing serves it"
+  else
+    bad "unexpected response for / ($ui_code $ui_type)"
+  fi
 
-# A client-side route must deliver the same shell: without the SPA fallback a
-# bookmark or refresh on /login 404s even though the app itself works.
-login_code=$(http_status GET /login)
-login_type=$(curl -s -o /dev/null -w '%{content_type}' "${BASE_URL}/login" || true)
-if [[ "$login_code" == "200" && "$login_type" == text/html* ]]; then
-  ok "client-side route /login falls back to the app shell (200)"
-else
-  bad "client-side route /login not served ($login_code $login_type)"
-fi
+  if [[ -n "$ui_body" ]] && printf '%s' "$ui_body" | grep -qi '<app-root'; then
+    ok "app shell present in the served document"
+  else
+    bad "document at / does not contain the Angular app shell"
+  fi
 
-# The inverse rule: a missing asset must not be answered with the shell, or the
-# browser reports a syntax error in "JavaScript" that is really HTML.
-missing_code=$(http_status GET /this-asset-does-not-exist.js)
-if [[ "$missing_code" == "404" ]]; then
-  ok "missing asset returns 404 (no SPA fallback for assets)"
-else
-  bad "missing asset returned $missing_code instead of 404 — SPA fallback is too greedy"
+  # A client-side route must deliver the same shell: without the SPA fallback a
+  # bookmark or refresh on /login 404s even though the app itself works.
+  login_code=$(http_status GET /login)
+  login_type=$(curl -s -o /dev/null -w '%{content_type}' "${BASE_URL}/login" || true)
+  if [[ "$login_code" == "200" && "$login_type" == text/html* ]]; then
+    ok "client-side route /login falls back to the app shell (200)"
+  else
+    bad "client-side route /login not served ($login_code $login_type)"
+  fi
+
+  # The inverse rule: a missing asset must not be answered with the shell, or the
+  # browser reports a syntax error in "JavaScript" that is really HTML.
+  missing_code=$(http_status GET /this-asset-does-not-exist.js)
+  if [[ "$missing_code" == "404" ]]; then
+    ok "missing asset returns 404 (no SPA fallback for assets)"
+  else
+    bad "missing asset returned $missing_code instead of 404 — SPA fallback is too greedy"
+  fi
 fi
 
 # --- 2. Auth enforcement: a protected endpoint must reject anonymous calls ---

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -82,6 +82,47 @@ else
   exit 1
 fi
 
+# --- 1b. Web UI delivery (Moddex#59) ---
+# The backend serves the built UI on this same port. Before that existed, an
+# installation could pass every API check here and still have no usable browser
+# interface, so these checks exist to make that state impossible to miss.
+ui_body="$(curl -s "${BASE_URL}/" || true)"
+ui_code=$(http_status GET /)
+ui_type=$(curl -s -o /dev/null -w '%{content_type}' "${BASE_URL}/" || true)
+
+if [[ "$ui_code" == "200" && "$ui_type" == text/html* ]]; then
+  ok "web UI served at / (200 $ui_type)"
+elif [[ "$ui_code" == "404" ]]; then
+  bad "no web UI at / (404) — the bundle installed no frontend, or nothing serves it"
+else
+  bad "unexpected response for / ($ui_code $ui_type)"
+fi
+
+if [[ -n "$ui_body" ]] && printf '%s' "$ui_body" | grep -qi '<app-root'; then
+  ok "app shell present in the served document"
+else
+  bad "document at / does not contain the Angular app shell"
+fi
+
+# A client-side route must deliver the same shell: without the SPA fallback a
+# bookmark or refresh on /login 404s even though the app itself works.
+login_code=$(http_status GET /login)
+login_type=$(curl -s -o /dev/null -w '%{content_type}' "${BASE_URL}/login" || true)
+if [[ "$login_code" == "200" && "$login_type" == text/html* ]]; then
+  ok "client-side route /login falls back to the app shell (200)"
+else
+  bad "client-side route /login not served ($login_code $login_type)"
+fi
+
+# The inverse rule: a missing asset must not be answered with the shell, or the
+# browser reports a syntax error in "JavaScript" that is really HTML.
+missing_code=$(http_status GET /this-asset-does-not-exist.js)
+if [[ "$missing_code" == "404" ]]; then
+  ok "missing asset returns 404 (no SPA fallback for assets)"
+else
+  bad "missing asset returned $missing_code instead of 404 — SPA fallback is too greedy"
+fi
+
 # --- 2. Auth enforcement: a protected endpoint must reject anonymous calls ---
 anon=$(http_status GET /api/v1/instance)
 if [[ "$anon" == "401" || "$anon" == "403" ]]; then

--- a/scripts/windows/build-bundle.ps1
+++ b/scripts/windows/build-bundle.ps1
@@ -78,7 +78,32 @@ try {
 } finally { Pop-Location }
 $frontendDist = Join-Path $FrontendDir 'dist'
 if (-not (Test-Path $frontendDist)) { Die "Frontend dist directory not found at $frontendDist" }
-Copy-Item -Path (Join-Path $frontendDist '*') -Destination (Join-Path $BundleDir 'frontend') -Recurse -Force
+
+# Angular's application builder emits to dist\<project>\browser by default, and
+# the project name is not something the packaging repo should hardcode. Copying
+# dist\* wholesale nests the app two levels too deep, and the backend - which
+# expects index.html directly under MODDEX_UI_DIR - then serves nothing
+# (the Windows counterpart of Moddex#61). Resolve the browser output from the
+# artefact that defines it: the shallowest directory containing index.html.
+$browserDir = Get-ChildItem -Path $frontendDist -Filter 'index.html' -File -Recurse |
+    Where-Object { $_.FullName -notmatch '[\\/](node_modules|server)[\\/]' } |
+    Sort-Object { $_.FullName.Split([IO.Path]::DirectorySeparatorChar).Count } |
+    Select-Object -First 1 -ExpandProperty DirectoryName
+
+if (-not $browserDir) {
+    Die "No index.html found under $frontendDist. The frontend build produced no browser output."
+}
+Write-Log "Frontend browser output: $browserDir"
+
+$frontendTarget = Join-Path $BundleDir 'frontend'
+New-Item -ItemType Directory -Force -Path $frontendTarget | Out-Null
+Copy-Item -Path (Join-Path $browserDir '*') -Destination $frontendTarget -Recurse -Force
+
+# The installer keys off exactly this path. Shipping a bundle without it means
+# installing a product with no user interface, so fail here rather than there.
+if (-not (Test-Path (Join-Path $frontendTarget 'index.html'))) {
+    Die 'Bundle assembly failed: frontend\index.html is missing from the bundle.'
+}
 
 # --- installer resources -----------------------------------------------------
 Write-Log 'Copying Windows installer resources'

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -55,6 +55,10 @@ $PortExplicit = $PSBoundParameters.ContainsKey('Port')
 # --- constants ---------------------------------------------------------------
 $ServiceId   = 'moddex-backend'
 $AppDir      = Join-Path $env:ProgramFiles 'Moddex'
+# Built web UI, served by the backend on the same port as the API (Moddex#59).
+# Mirrors the Linux layout (/opt/moddex/ui): it lives with the application, not
+# with the instance data, because an upgrade replaces it wholesale.
+$UiDir       = Join-Path $AppDir 'ui'
 $DataRoot    = Join-Path $env:ProgramData 'Moddex'
 $DataDir     = Join-Path $DataRoot 'data'
 $ConfigDir   = Join-Path $DataRoot 'config'
@@ -246,9 +250,16 @@ if (Get-Service -Name $ServiceId -ErrorAction SilentlyContinue) {
 
 Write-Log 'Installing application artifacts ...'
 Copy-Item -Path $BackendJar -Destination (Join-Path $AppDir 'app.jar') -Force
-$frontendTarget = Join-Path $AppDir 'frontend'
-if (Test-Path $frontendTarget) { Remove-Item -Recurse -Force $frontendTarget }
-Copy-Item -Path $FrontendDir -Destination $frontendTarget -Recurse -Force
+if (Test-Path $UiDir) { Remove-Item -Recurse -Force $UiDir }
+Copy-Item -Path $FrontendDir -Destination $UiDir -Recurse -Force
+
+# One-time migration: earlier installs put the assets in <AppDir>\frontend,
+# where nothing served them.
+$legacyFrontend = Join-Path $AppDir 'frontend'
+if (Test-Path $legacyFrontend) {
+    Write-Log "Removing the obsolete UI directory at $legacyFrontend (now served from $UiDir)"
+    Remove-Item -Recurse -Force $legacyFrontend
+}
 
 # Record the installed version for parity with Linux (/opt/moddex/VERSION) so
 # operators can verify an upgrade (Get-Content "$env:ProgramFiles\Moddex\VERSION").
@@ -275,6 +286,7 @@ $substitutions = [ordered]@{
     '@@DATA_DIR@@'       = $DataDir
     '@@CONFIG_DIR@@'     = $ConfigDir
     '@@LOG_DIR@@'        = $LogDir
+    '@@UI_DIR@@'         = $UiDir
     '@@MODE@@'           = $cfg.Mode
     '@@SERVER_ADDRESS@@' = $cfg.Address
     '@@SERVER_PORT@@'    = [string]$cfg.Port

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -215,6 +215,19 @@ if (-not $FrontendDir) { $FrontendDir = Join-Path $BundleRoot 'frontend' }
 if (-not (Test-Path $BackendJar))  { Die "Backend JAR not found: $BackendJar" }
 if (-not (Test-Path $FrontendDir)) { Die "Frontend assets not found: $FrontendDir" }
 
+# Checked here, before anything is stopped or deleted. The backend serves
+# index.html straight out of MODDEX_UI_DIR, so a directory without one at its
+# root is unusable - and validating it later would mean tearing down a working
+# installation first and then reporting success over the wreckage. Matches the
+# Linux installer's check (Moddex#59/#61).
+if (-not (Test-Path (Join-Path $FrontendDir 'index.html'))) {
+    Die @"
+Frontend directory has no index.html at its root: $FrontendDir
+This is not a built Angular app. Point -FrontendDir at the browser output
+(the directory containing index.html), not at the dist\ root.
+"@
+}
+
 $cfg = Resolve-Config -RequestedMode $Mode -RequestedPort $Port `
     -ModeWasGiven $ModeExplicit -PortWasGiven $PortExplicit
 Write-Log "Mode=$($cfg.Mode) Address=$($cfg.Address) Port=$($cfg.Port)"

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -140,7 +140,7 @@ function Resolve-WinSw {
 # Env names the template renders from -Mode/-Port; everything else in an existing
 # service definition was added by the operator and must survive an upgrade.
 $ManagedEnv = @(
-    'MODDEX_ROOT', 'MODDEX_CONFIG_DIR', 'MODDEX_LOG_DIR',
+    'MODDEX_ROOT', 'MODDEX_CONFIG_DIR', 'MODDEX_LOG_DIR', 'MODDEX_UI_DIR',
     'MODDEX_MODE', 'MODDEX_SECURITY_MODE', 'SERVER_ADDRESS', 'SERVER_PORT'
 )
 

--- a/scripts/windows/smoke-test.ps1
+++ b/scripts/windows/smoke-test.ps1
@@ -31,14 +31,25 @@ function Ok([string]$m)   { Write-Host "[ OK ] $m" -ForegroundColor Green }
 function Bad([string]$m)  { Write-Host "[FAIL] $m" -ForegroundColor Red; $script:failures++ }
 function Info([string]$m) { Write-Host "[ -- ] $m" }
 
+# Returns the HTTP status code, or 0 when there was no response at all.
+#
+# The two PowerShell editions raise different exceptions for an error status:
+# Windows PowerShell 5.1 throws System.Net.WebException, PowerShell 7 throws
+# Microsoft.PowerShell.Commands.HttpResponseException. Catching only the former
+# made every 4xx look like "no response" under PowerShell 7 — so a backend
+# correctly answering 404 for a missing asset failed the check. Both carry the
+# response on .Exception.Response, so one handler covers both editions.
 function Get-Status([string]$Path) {
     try {
         $r = Invoke-WebRequest -Uri "$BaseUrl$Path" -Method GET -UseBasicParsing -TimeoutSec 5
         return [int]$r.StatusCode
-    } catch [System.Net.WebException] {
-        if ($_.Exception.Response) { return [int]$_.Exception.Response.StatusCode }
+    } catch {
+        $response = $_.Exception.PSObject.Properties['Response']
+        if ($response -and $response.Value) {
+            return [int]$response.Value.StatusCode
+        }
         return 0
-    } catch { return 0 }
+    }
 }
 
 Info "Installing Moddex (local mode, port $Port) ..."

--- a/scripts/windows/smoke-test.ps1
+++ b/scripts/windows/smoke-test.ps1
@@ -62,6 +62,37 @@ else { Bad "service not running: $(if ($svc) { $svc.Status } else { 'absent' })"
 
 # Protected endpoint must reject anonymous access.
 $anon = Get-Status '/api/v1/instance'
+# Web UI delivery (Moddex#59). The backend serves the built UI on this same
+# port. Without these checks an installation can pass every API assertion here
+# and still have no usable browser interface - which is exactly how the defect
+# went unnoticed on Linux.
+$uiCode = Get-Status '/'
+if ($uiCode -eq 200) {
+    Ok "web UI served at / (200)"
+    try {
+        $uiBody = (Invoke-WebRequest -Uri "$BaseUrl/" -UseBasicParsing -TimeoutSec 5).Content
+        if ($uiBody -match '<app-root') { Ok 'app shell present in the served document' }
+        else { Bad 'document at / does not contain the Angular app shell' }
+    } catch {
+        Bad "could not read the document at /: $($_.Exception.Message)"
+    }
+} elseif ($uiCode -eq 404) {
+    Bad 'no web UI at / (404) - the bundle installed no frontend, or MODDEX_UI_DIR is wrong'
+} else {
+    Bad "unexpected response for / ($uiCode)"
+}
+
+# A client-side route must deliver the same shell: without the SPA fallback a
+# bookmark or refresh on /login 404s even though the app itself works.
+$loginCode = Get-Status '/login'
+if ($loginCode -eq 200) { Ok 'client-side route /login falls back to the app shell (200)' }
+else { Bad "client-side route /login not served ($loginCode)" }
+
+# The inverse rule: a missing asset must not be answered with the shell.
+$missingCode = Get-Status '/this-asset-does-not-exist.js'
+if ($missingCode -eq 404) { Ok 'missing asset returns 404 (no SPA fallback for assets)' }
+else { Bad "missing asset returned $missingCode instead of 404 - SPA fallback is too greedy" }
+
 if ($anon -eq 401 -or $anon -eq 403) { Ok "auth enforced (/instance -> $anon without a token)" }
 elseif ($anon -eq 200) { Bad '/instance served WITHOUT a token (200) - auth not enforced' }
 else { Info "unexpected anonymous status for /instance: $anon (continuing)" }

--- a/scripts/windows/smoke-test.ps1
+++ b/scripts/windows/smoke-test.ps1
@@ -36,7 +36,7 @@ function Info([string]$m) { Write-Host "[ -- ] $m" }
 # The two PowerShell editions raise different exceptions for an error status:
 # Windows PowerShell 5.1 throws System.Net.WebException, PowerShell 7 throws
 # Microsoft.PowerShell.Commands.HttpResponseException. Catching only the former
-# made every 4xx look like "no response" under PowerShell 7 — so a backend
+# made every 4xx look like "no response" under PowerShell 7 - so a backend
 # correctly answering 404 for a missing asset failed the check. Both carry the
 # response on .Exception.Response, so one handler covers both editions.
 function Get-Status([string]$Path) {
@@ -71,8 +71,6 @@ $svc = Get-Service -Name 'moddex-backend' -ErrorAction SilentlyContinue
 if ($svc -and $svc.Status -eq 'Running') { Ok "service status: $($svc.Status)" }
 else { Bad "service not running: $(if ($svc) { $svc.Status } else { 'absent' })" }
 
-# Protected endpoint must reject anonymous access.
-$anon = Get-Status '/api/v1/instance'
 # Web UI delivery (Moddex#59). The backend serves the built UI on this same
 # port. Without these checks an installation can pass every API assertion here
 # and still have no usable browser interface - which is exactly how the defect
@@ -104,6 +102,8 @@ $missingCode = Get-Status '/this-asset-does-not-exist.js'
 if ($missingCode -eq 404) { Ok 'missing asset returns 404 (no SPA fallback for assets)' }
 else { Bad "missing asset returned $missingCode instead of 404 - SPA fallback is too greedy" }
 
+# Protected endpoint must reject anonymous access.
+$anon = Get-Status '/api/v1/instance'
 if ($anon -eq 401 -or $anon -eq 403) { Ok "auth enforced (/instance -> $anon without a token)" }
 elseif ($anon -eq 200) { Bad '/instance served WITHOUT a token (200) - auth not enforced' }
 else { Info "unexpected anonymous status for /instance: $anon (continuing)" }


### PR DESCRIPTION
Closes #59 (Installer-Seite). Die Backend-Seite ist Moddex-Backend#61, bereits gemergt.

## Was fehlte

Der Installer kopierte die Frontend-Assets nach `/var/lib/moddex/ui` und meldete dann woertlich:

```
Static frontend copied to /var/lib/moddex/ui (serve separately).
```

„Serve separately" — nur tat das niemand. Die systemd-Unit startet allein das Backend-JAR, und das Backend hatte keinen Resource-Handler. Danach kam trotzdem `Installation complete`.

## Die Aenderung

Das Backend liefert die UI jetzt selbst aus. Der Installer legt sie dorthin, wo das Backend sie sucht:

- **`/opt/moddex/ui`** statt `/var/lib/moddex/ui`. Die UI gehoert zur Anwendung, nicht zu den Instanzdaten — sie wird bei jedem Upgrade vollstaendig ersetzt. Jetzt `root:root` und fuer den Dienst nur lesbar, damit zur Laufzeit nichts veraendern kann, was Browser ausgeliefert bekommen. Ein Upgrade raeumt den alten Ort weg statt eine tote Kopie liegen zu lassen.
- **`MODDEX_UI_DIR`** in systemd-Unit *und* `moddex.env`, bewusst ausserhalb von `ReadWritePaths`.
- **Die Abschlussmeldung** wirbt nicht mehr fuer einen zweiten Webserver, sondern nennt **eine** Adresse fuer UI und API. Eine `--without-frontend`-Installation sagt ausdruecklich, dass die Browser-Oberflaeche fehlt.
- **Der Smoke-Test** prueft, was den urspruenglichen Defekt gefunden haette: `/` liefert `200 text/html` mit App-Shell, `/login` faellt auf dieselbe Shell zurueck, ein fehlendes Asset liefert `404` statt HTML.

## Review-Befunde (sieben Runden)

| Befund | Bewertung |
|---|---|
| Upgrade startete den Dienst nie neu (`enable --now` startet Laufendes nicht neu) | zutreffend, **P1** — verschaerft durch die UI-Migration: altes Verzeichnis geloescht, neues nie ausgeliefert |
| Windows hatte gar keine UI: Assets in `\frontend`, kein `MODDEX_UI_DIR` im WinSW-Template | zutreffend, **P1** |
| `MODDEX_UI_DIR` fehlte in `$ManagedEnv` → Duplikate bei jedem Re-Install | zutreffend |
| Smoke-Test scheiterte immer bei `--without-frontend` | zutreffend — ich hatte die Option als unterstuetzt erklaert und dann einen Test geschrieben, der dafuer immer rot ist |
| Windows-Bundler kopierte die verschachtelte Angular-Ausgabe (Windows-Aequivalent zu #61) | zutreffend, **P1** |
| Windows validierte `-FrontendDir` nicht auf `index.html` → loeschte eine funktionierende UI und meldete Erfolg | zutreffend |
| `Get-Status` fing nur `WebException`; PowerShell 7 wirft `HttpResponseException` → jeder 404 kam als „0" an | zutreffend, mit pwsh 7.6.4 reproduziert |

**Selbst geprueft und bewusst nicht geaendert:** die Unit listet `EnvironmentFile=` vor ihren `Environment=`-Defaults, was so aussieht, als wuerde `SERVER_ADDRESS` aus `moddex.env` ueberschrieben. Wird es nicht. systemd wendet `EnvironmentFile` unabhaengig von der Direktiven-Reihenfolge nach `Environment=` an — mit `systemd-run` in beiden Reihenfolgen gemessen, die Datei gewinnt jedes Mal.

## Verifikation

Smoke-Test gegen ein laufendes Backend in allen drei Zustaenden:

| Zustand | Ergebnis |
|---|---|
| UI vorhanden, ohne Flag | 6 bestanden, 0 fehlgeschlagen |
| UI fehlt, ohne Flag | 3 fehlgeschlagen, exit 1 — benennt fehlende UI, fehlende App-Shell, nicht ausgelieferte `/login`-Route |
| UI fehlt, mit `--without-frontend` | 2 bestanden, 0 fehlgeschlagen, exit 0 |

Windows-Seite ohne Windows-Runner geprueft, soweit moeglich: PSScriptAnalyzer sauber ueber alle vier Skripte (inkl. 5.1-Syntaxkompatibilitaet), die gerenderte Dienstdefinition loest jeden Platzhalter auf und traegt `MODDEX_UI_DIR` bei gueltigem XML, die Browser-Ausgabe-Aufloesung findet `dist/Moddex-Frontend/browser` an der echten Angular-Ausgabe, alle drei Zweige der Frontend-Validierung verhalten sich richtig, und `Get-Status` liefert 200/404/0 korrekt.

`shellcheck` und der Lint-Stage der Pipeline sind gruen.

## Was das nicht loest

Staging, Readiness-Gate und Rollback um das Upgrade herum bleiben **#62**. Dieser PR ergaenzt nur den fehlenden Neustart, ohne den die UI-Migration einen schlechteren Zustand hinterlassen haette als vorher.
